### PR TITLE
Add Fixed spacing etc. ea-scripts files

### DIFF
--- a/ea-scripts/Fixed spacing.md
+++ b/ea-scripts/Fixed spacing.md
@@ -1,0 +1,32 @@
+/*
+![](https://raw.githubusercontent.com/zsviczian/obsidian-excalidraw-plugin/master/images/scripts-download-raw.jpg)
+
+Download this file and save to your Obsidian Vault including the first line, or open it in "Raw" and copy the entire contents to Obsidian.
+
+This script aligns the selected elements horizontally with a fixed spacing.
+
+When we create an architecture diagram or mind map, we often need to arrange a large number of elements in a fixed spacing. `Fixed spacing` and `Fixed vertical Distance` scripts can save us a lot of time.
+
+```javascript
+*/
+const spacing = parseInt (await utils.inputPrompt("spacing?","number","8"));
+const elements=ea.getViewSelectedElements();
+const topGroups = ea.getMaximumGroups(elements);
+const groups = topGroups.sort((lha,rha) => lha[0].x - rha[0].x);
+
+for(var i=0; i<groups.length; i++) {
+    if(i > 0) {
+        const preGroup = groups[i-1];
+        const curGroup = groups[i];
+
+        const preRight = Math.max(...preGroup.map(el => el.x + el.width));
+        const curLeft = Math.min(...curGroup.map(el => el.x));
+        const distance = curLeft -  preRight - spacing;
+
+        for(const curEl of curGroup) {
+            curEl.x = curEl.x - distance;
+        }
+    }
+}
+ea.copyViewElementsToEAforEditing(elements);
+ea.addElementsToView();

--- a/ea-scripts/Fixed spacing.md
+++ b/ea-scripts/Fixed spacing.md
@@ -3,7 +3,7 @@
 
 Download this file and save to your Obsidian Vault including the first line, or open it in "Raw" and copy the entire contents to Obsidian.
 
-This script aligns the selected elements horizontally with a fixed spacing.
+The script arranges the selected elements horizontally with a fixed spacing.
 
 When we create an architecture diagram or mind map, we often need to arrange a large number of elements in a fixed spacing. `Fixed spacing` and `Fixed vertical Distance` scripts can save us a lot of time.
 

--- a/ea-scripts/Fixed vertical distance.md
+++ b/ea-scripts/Fixed vertical distance.md
@@ -3,7 +3,7 @@
 
 Download this file and save to your Obsidian Vault including the first line, or open it in "Raw" and copy the entire contents to Obsidian.
 
-The script arranges the selected elements vertically at fixed spacing.
+The script arranges the selected elements vertically with a fixed spacing.
 
 When we create an architecture diagram or mind map, we often need to arrange a large number of elements in a fixed spacing. `Fixed spacing` and `Fixed vertical Distance` scripts can save us a lot of time.
 

--- a/ea-scripts/Fixed vertical distance.md
+++ b/ea-scripts/Fixed vertical distance.md
@@ -1,0 +1,32 @@
+/*
+![](https://raw.githubusercontent.com/zsviczian/obsidian-excalidraw-plugin/master/images/scripts-download-raw.jpg)
+
+Download this file and save to your Obsidian Vault including the first line, or open it in "Raw" and copy the entire contents to Obsidian.
+
+The script arranges the selected elements vertically at fixed spacing.
+
+When we create an architecture diagram or mind map, we often need to arrange a large number of elements in a fixed spacing. `Fixed spacing` and `Fixed vertical Distance` scripts can save us a lot of time.
+
+```javascript
+*/
+const spacing = parseInt (await utils.inputPrompt("spacing?","number","8"));
+const elements=ea.getViewSelectedElements();
+const topGroups = ea.getMaximumGroups(elements);
+const groups = topGroups.sort((lha,rha) => lha[0].y - rha[0].y);
+
+for(var i=0; i<groups.length; i++) {
+    if(i > 0) {
+        const preGroup = groups[i-1];
+        const curGroup = groups[i];
+
+        const preBottom = Math.max(...preGroup.map(el => el.y + el.height));
+        const curTop = Math.min(...curGroup.map(el => el.y));
+        const distance = curTop -  preBottom - spacing;
+
+        for(const curEl of curGroup) {
+            curEl.y = curEl.y - distance;
+        }
+    }
+}
+ea.copyViewElementsToEAforEditing(elements);
+ea.addElementsToView();


### PR DESCRIPTION
`Fixed spacing` arranges the selected elements horizontally with a fixed spacing.
`Fixed vertical distance` arranges the selected elements vertically with a fixed spacing.

When we create an architecture diagram or mind map, we often need to arrange a large number of elements in a fixed spacing. `Fixed spacing` and `Fixed vertical Distance` scripts can save us a lot of time.

ps. My English is not good, if you have a more appropriate script name, please help me correct it.