### PR TITLE
Fix unnecessary changes to text placement

### DIFF
--- a/ea-scripts/Expand rectangles horizontally.md
+++ b/ea-scripts/Expand rectangles horizontally.md
@@ -52,9 +52,7 @@ for (var i = 0; i < topGroups.length; i++) {
   const rects = topGroups[i]
     .filter((el) => el.type === "rectangle")
     .sort((lha, rha) => lha.x - rha.x);
-  const texts = topGroups[i]
-    .filter((el) => el.type === "text")
-    .sort((lha, rha) => lha.x - rha.x);
+
   const groupWith = groupWidths[i].width;
   if (groupWith < maxGroupWidth) {
     const distance = maxGroupWidth - groupWith;
@@ -63,10 +61,6 @@ for (var i = 0; i < topGroups.length; i++) {
       const rect = rects[j];
       rect.x = rect.x + perRectDistance * j;
       rect.width += perRectDistance;
-    }
-    for (var j = 0; j < texts.length; j++) {
-      const text = texts[j];
-      text.x = text.x + perRectDistance * j;
     }
   }
 }

--- a/ea-scripts/Expand rectangles vertically.md
+++ b/ea-scripts/Expand rectangles vertically.md
@@ -49,9 +49,7 @@ for (var i = 0; i < topGroups.length; i++) {
   const rects = topGroups[i]
     .filter((el) => el.type === "rectangle")
     .sort((lha, rha) => lha.y - rha.y);
-  const texts = topGroups[i]
-    .filter((el) => el.type === "text")
-    .sort((lha, rha) => lha.y - rha.y);
+
   const groupWith = groupHeights[i].height;
   if (groupWith < maxGroupHeight) {
     const distance = maxGroupHeight - groupWith;
@@ -60,10 +58,6 @@ for (var i = 0; i < topGroups.length; i++) {
       const rect = rects[j];
       rect.y = rect.y + perRectDistance * j;
       rect.height += perRectDistance;
-    }
-    for (var j = 0; j < texts.length; j++) {
-      const text = texts[j];
-      text.y = text.y + perRectDistance * j;
     }
   }
 }


### PR DESCRIPTION
`Expand rectangles horizontally` and `Expand rectangles vertically` should not change the position of text elements.