### PR TITLE
Don't override menu scope in hover editor

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -101,6 +101,12 @@ declare module "obsidian" {
   interface App {
     isMobile(): boolean;
   }
+  interface Keymap {
+    getRootScope(): Scope
+  }
+  interface Scope {
+    keys: any[]
+  }
   interface Workspace {
     on(
       name: "hover-link",
@@ -1508,16 +1514,10 @@ export default class ExcalidrawPlugin extends Plugin {
           self.popScope = null;
         }
         if (newActiveviewEV) {
-          //@ts-ignore
-          const scope = new Scope(self.app.scope);
-          scope.register(["Mod"], "Enter", () => true);
-          
-          //@ts-ignore
-          self.app.keymap.pushScope(scope);
-          self.popScope = () => {
-            //@ts-ignore
-            self.app.keymap.popScope(scope);
-          };
+          const scope = this.app.keymap.getRootScope();
+          const handler = scope.register(["Mod"], "Enter", () => true);
+          scope.keys.unshift(scope.keys.pop());  // Force our handler to the front of the list
+          self.popScope = () => scope.unregister(handler);
         }
       };
       self.registerEvent(


### PR DESCRIPTION
When used with the Hover Editor plugin and the menus of Quick Explorer or Pane Relief, the old way of pushing a scope caused Excalidraw to take control away from the menu scope.  This change adds a handler to the app's root scope at a precedence above hotkey commands, but below that of any currently-pushed scopes (such as menus or modals).

(See https://github.com/nothingislost/obsidian-hover-editor/issues/85 for more background.)