### PR TITLE
Change the default sticky note to have transparent border

### DIFF
--- a/ea-scripts/Convert selected text elements to sticky notes.md
+++ b/ea-scripts/Convert selected text elements to sticky notes.md
@@ -15,7 +15,7 @@ settings = ea.getScriptSettings();
 if(!settings["Border color"]) {
 	settings = {
 	  "Border color" : {
-			value: "#000000",
+			value: "transparent",
       description: "Any legal HTML color (#000000, rgb, color-name, etc.). Set to 'transparent' for transparent color."
 		},
 		"Background color" : {


### PR DESCRIPTION
In this video: https://youtu.be/fXGcOWycgG4?t=1923
it is mentioned that the default border color for the "Convert selected text elements to sticky notes" script is a transparent border, however that is not the current default value.

I think setting `transparent` as the default is more useful than `#000000` because `transparent` can only be set via a script (at least without affecting the text color) while `#000000` can be set since it is also a common color for text.