### PR TITLE
Fixed issue with mindmap format script that elements within group were not formatted along with selected element

### DIFF
--- a/ea-scripts/Mindmap format.md
+++ b/ea-scripts/Mindmap format.md
@@ -55,6 +55,8 @@ if (!settings["MindMap Format"]) {
   ea.setScriptSettings(settings);
 }
 
+const sceneElements = ea.getExcalidrawAPI().getSceneElements();
+
 // default X coordinate of the middle point of the arc
 const defaultDotX = Number(settings["curve length"].value);
 // The default length from the middle point of the arc on the X axis
@@ -137,9 +139,16 @@ const setTextXY = (rect, text) => {
 };
 
 const setChildrenXY = (parent, children, line, elementsMap) => {
-  children.x = parent.x + parent.width + line.points[2][0];
-  children.y =
-    parent.y + parent.height / 2 + line.points[2][1] - children.height / 2;
+  x = parent.x + parent.width + line.points[2][0];
+  y = parent.y + parent.height / 2 + line.points[2][1] - children.height / 2;
+  distX = children.x - x;
+  distY = children.y - y;
+
+  ea.getElementsInTheSameGroupWithElement(children, sceneElements).forEach((el) => {
+    el.x = el.x - distX;
+    el.y = el.y - distY;
+  });
+
   if (
     ["rectangle", "diamond", "ellipse"].includes(children.type) &&
     ![null, undefined].includes(children.boundElements)


### PR DESCRIPTION
<img width="179" alt="image" src="https://github.com/zsviczian/obsidian-excalidraw-plugin/assets/25865048/c989da26-4fa6-4d73-9681-f0b66b8d0ca3">

Before:
<img width="178" alt="image" src="https://github.com/zsviczian/obsidian-excalidraw-plugin/assets/25865048/913bbb38-f7fb-4bf6-b5d5-1725201b9112">

After:
<img width="148" alt="image" src="https://github.com/zsviczian/obsidian-excalidraw-plugin/assets/25865048/1fc74c8c-f20c-465b-ab80-a60626189f90">
