### PR TITLE
Fix Excalidraw Pasting with middle mouse button on linux

### DIFF
--- a/src/ExcalidrawView.ts
+++ b/src/ExcalidrawView.ts
@@ -3269,6 +3269,9 @@ export default class ExcalidrawView extends TextFileView {
                 await this.plugin.saveSettings();
               })();
             },
+
+            // TODO: Potentially better way to block middle mouse paste on linux:
+            //! onauxclick: (e: any) => {e.preventDefault()}, 
             renderTopRightUI:  (isMobile: boolean, appState: AppState) => this.obsidianMenu.renderButton (isMobile, appState),
             renderEmbeddableMenu: (appState: AppState) => this.embeddableMenu.renderButtons(appState),
             onPaste: (
@@ -3287,6 +3290,18 @@ export default class ExcalidrawView extends TextFileView {
                 });
                 if(typeof res === "boolean" && res === false) return false;
               }
+
+              // Disables Middle Mouse Button Paste Functionality on Linux
+              if(
+                !this.modifierKeyDown.ctrlKey 
+                && typeof event !== "undefined"
+                && event !== null 
+                && DEVICE.isLinux
+                ) {
+                console.debug("Prevented what is likely middle mouse button paste.")
+                return false
+              };
+
               if(data && data.text && hyperlinkIsImage(data.text)) {
                 this.addImageWithURL(data.text);
                 return false;
@@ -3325,6 +3340,9 @@ export default class ExcalidrawView extends TextFileView {
               }
               return true;
             },
+
+
+
             onThemeChange: async (newTheme: string) => {
               //debug({where:"ExcalidrawView.onThemeChange",file:this.file.name,before:"this.loadSceneFiles",newTheme});
               this.excalidrawData.scene.appState.theme = newTheme;


### PR DESCRIPTION
Pretty primtiive check, but it seems to work from my testing, either way it will only have an effect on linux since it checks for DEVICE.isLinux().


### This video shows how the issue is fixed, and how often it occurs normally.
https://github.com/zsviczian/obsidian-excalidraw-plugin/assets/96164686/7998c865-9db9-4e3f-9894-c61f2b4d0b26

>(It doesn't happen everytime you try pan, but it happens often enough that I booted into windows at points just to use excalidraw)


I also left in a comment that references auxclick, I couldn't get that one to work, however it should be possible to do with auxclick according to [this from the MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/auxclick_event#preventing_default_actions)




Fixes: https://github.com/zsviczian/obsidian-excalidraw-plugin/issues/1215 *---  [:)](https://youtu.be/L_WoOkDAqbM)*