### PR TITLE
Replace outlier var declarations with let declarations

### DIFF
--- a/src/utils/FileUtils.ts
+++ b/src/utils/FileUtils.ts
@@ -280,9 +280,9 @@ export const getDataURLFromURL = async (
 export const blobToBase64 = async (blob: Blob): Promise<string> => {
   const arrayBuffer = await blob.arrayBuffer()
   const bytes = new Uint8Array(arrayBuffer)
-  var binary = '';
-  var len = bytes.byteLength;
-  for (var i = 0; i < len; i++) {
+  let binary = '';
+  let len = bytes.byteLength;
+  for (let i = 0; i < len; i++) {
     binary += String.fromCharCode(bytes[i]);
   }
   return btoa(binary);


### PR DESCRIPTION
Replaces outlier `var` declarations with `let` declarations. `let` is used much more frequently in this repository.