### PR TITLE
Use ‘px’ unit for LaTeX images to make them compatible with Inkscape

### DIFF
--- a/src/LaTeX.ts
+++ b/src/LaTeX.ts
@@ -86,13 +86,16 @@ export async function tex2dataURL(
       if(svg.width.baseVal.valueInSpecifiedUnits < 2) {
         svg.width.baseVal.valueAsString = `${(svg.width.baseVal.valueInSpecifiedUnits+1).toFixed(3)}ex`;
       }
+      const img = svgToBase64(svg.outerHTML);
+      svg.width.baseVal.valueAsString = (svg.width.baseVal.valueInSpecifiedUnits * 100).toFixed(3);
+      svg.height.baseVal.valueAsString = (svg.height.baseVal.valueInSpecifiedUnits * 100).toFixed(3);
       const dataURL = svgToBase64(svg.outerHTML);
       return {
         mimeType: "image/svg+xml",
         fileId: fileid() as FileId,
         dataURL: dataURL as DataURL,
         created: Date.now(),
-        size: await getImageSize(dataURL),
+        size: await getImageSize(img),
       };
     }
   } catch (e) {


### PR DESCRIPTION
Excalidraw plugin generates LaTeX images using MathJax. MathJax uses the ‘ex’ unit for the width and height of the SVG output by default. However, this causes a problem when using Inkscape to convert SVG to PDF, which is a common method for embedding SVG images into TeX files. Inkscape does not support the ‘ex’ unit and renders the images incorrectly.

To solve this issue, this PR changes the MathJax configuration to use the ‘px’ unit instead of the ‘ex’ unit for the LaTeX images. This ensures that the images have the correct size and are compatible with Inkscape. This allows us to use LaTeX formulas for the images that are embedded in TeX files without any distortion.

Note that, since the actual pixel value of 1 ex is not available at run time, I have used a fixed conversion factor of 100 to multiply the ex unit value. This seems to work well in practice.