### PR TITLE
Add default image height setting

### DIFF
--- a/src/MarkdownPostProcessor.ts
+++ b/src/MarkdownPostProcessor.ts
@@ -50,6 +50,14 @@ const getDefaultWidth = (plugin: ExcalidrawPlugin): string => {
   return plugin.settings.width;
 };
 
+const getDefaultHeight = (plugin: ExcalidrawPlugin): string => {
+  const height = parseInt(plugin.settings.height);
+  if (isNaN(height) || height === 0 || height === null) {
+    return null;
+  }
+  return plugin.settings.height;
+};
+
 export const initializeMarkdownPostProcessor = (p: ExcalidrawPlugin) => {
   plugin = p;
   vault = p.app.vault;
@@ -512,7 +520,9 @@ const processInternalEmbed = async (internalEmbedEl: Element, file: TFile ):Prom
   attr.fwidth = internalEmbedEl.getAttribute("width")
   ? internalEmbedEl.getAttribute("width")
   : getDefaultWidth(plugin);
-  attr.fheight = internalEmbedEl.getAttribute("height");
+  attr.fheight = internalEmbedEl.getAttribute("height")
+  ? internalEmbedEl.getAttribute("height")
+  : getDefaultHeight(plugin);
   let alt = internalEmbedEl.getAttribute("alt");
   attr.style = ["excalidraw-svg"];
   processAltText(src.split("#")[0],alt,attr);
@@ -596,7 +606,7 @@ const tmpObsidianWYSIWYG = async (
 
   const attr: imgElementAttributes = {
     fname: ctx.sourcePath,
-    fheight: "",
+    fheight: getDefaultHeight(plugin),
     fwidth: getDefaultWidth(plugin),
     style: ["excalidraw-svg"],
   };

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -469,6 +469,11 @@ FILENAME_HEAD: "Filename",
     "The default width of an embedded drawing. This applies to live preview edit and reading mode, as well as to hover previews. You can specify a custom " +
     "width when embedding an image using the <code>![[drawing.excalidraw|100]]</code> or " +
     "<code>[[drawing.excalidraw|100x100]]</code> format.",
+  EMBED_HEIGHT_NAME: "Default height of embedded (transcluded) image",
+  EMBED_HEIGHT_DESC:
+    "The default height of an embedded drawing. This applies to live preview edit and reading mode, as well as to hover previews. You can specify a custom " +
+    "height when embedding an image using the <code>![[drawing.excalidraw|100]]</code> or " +
+    "<code>[[drawing.excalidraw|100x100]]</code> format.",
   EMBED_TYPE_NAME: "Type of file to insert into the document",
   EMBED_TYPE_DESC:
     "When you embed an image into a document using the command palette this setting will specify if Excalidraw should embed the original Excalidraw file " +

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1629,6 +1629,20 @@ export class ExcalidrawSettingTab extends PluginSettingTab {
             this.requestEmbedUpdate = true;
           }),
       );
+    
+      new Setting(detailsEl)
+      .setName(t("EMBED_HEIGHT_NAME"))
+      .setDesc(fragWithHTML(t("EMBED_HEIGHT_DESC")))
+      .addText((text) =>
+        text
+          .setPlaceholder("e.g.: 400")
+          .setValue(this.plugin.settings.height)
+          .onChange(async (value) => {
+            this.plugin.settings.height = value;
+            this.applySettingsUpdate();
+            this.requestEmbedUpdate = true;
+          }),
+      );
 
     let scaleText: HTMLDivElement;
 


### PR DESCRIPTION
The default image width setting is great for controlling the horizontal size of embedded images, but sometimes I end up with very narrow and tall images. The ![[Drawing.excalidraw|200x200]] syntax for controlling height is useful, but it would be easier to have default height as a setting instead of pasting it onto every image I have.

Currently marked as a draft because I have an older version of the plugin and won't be able to fully test this for a while, but leaving this open in case someone else wants to take this patch as a starting point and get it merged in.