### PR TITLE
FR: Update Excalidraw Folder setting to allow saving drawings in the current folder or subfolder within current folder #1348

### DIFF
--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -128,7 +128,7 @@ export default {
   BASIC_DESC: `In the "Basic" settings, you can configure options such as displaying release notes after updates, receiving plugin update notifications, setting the default location for new drawings, specifying the Excalidraw folder for embedding drawings into active documents, defining an Excalidraw template file, and designating an Excalidraw Automate script folder for managing automation scripts.`,
   FOLDER_NAME: "Excalidraw folder",
   FOLDER_DESC:
-    "Default location for new drawings. If empty, drawings will be created in the Vault root.",
+    "Default folder location for new drawings at vault root. <ul><li>If \"./\", drawings will be saved in same folder as the current file.</li> <li>If \"./{folder}\", drawings will be saved to the folder specified in the same folder as the current.</li> <li>If empty, drawings will be created in the Vault root.</li></ul>",
   CROP_PREFIX_NAME: "Crop file prefix",
   CROP_PREFIX_DESC:
     "The first part of the filename for new drawings created when cropping an image. " +

--- a/src/main.ts
+++ b/src/main.ts
@@ -98,7 +98,7 @@ import {
   isCallerFromTemplaterPlugin,
   decompress,
 } from "./utils/Utils";
-import { extractSVGPNGFileName, getActivePDFPageNumberFromPDFView, getAttachmentsFolderAndFilePath, getNewOrAdjacentLeaf, getParentOfClass, isObsidianThemeDark, openLeaf } from "./utils/ObsidianUtils";
+import { extractSVGPNGFileName, getActivePDFPageNumberFromPDFView, getAttachmentsFolderAndFilePath, getCurrentActiveDirectory, getNewOrAdjacentLeaf, getParentOfClass, isObsidianThemeDark, openLeaf } from "./utils/ObsidianUtils";
 import { ExcalidrawElement, ExcalidrawEmbeddableElement, ExcalidrawImageElement, ExcalidrawTextElement, FileId } from "@zsviczian/excalidraw/types/excalidraw/element/types";
 import { ScriptEngine } from "./Scripts";
 import {
@@ -1093,7 +1093,7 @@ export default class ExcalidrawPlugin extends Plugin {
         this.settings,
       );
       const folder = this.settings.embedUseExcalidrawFolder
-        ? null
+        ? (this.settings.folder && this.settings.folder.startsWith("./")) ? getCurrentActiveDirectory(activeView.file.path, this.settings.folder) : null
         : (
             await getAttachmentsFolderAndFilePath(
               this.app,
@@ -1101,6 +1101,7 @@ export default class ExcalidrawPlugin extends Plugin {
               filename,
             )
           ).folder;
+
       const file = await this.createDrawing(filename, folder);
       await this.embedDrawing(file);
       this.openDrawing(file, location, true, undefined, true);

--- a/src/utils/ObsidianUtils.ts
+++ b/src/utils/ObsidianUtils.ts
@@ -169,9 +169,7 @@ export const getAttachmentsFolderAndFilePath = async (
   // folder == "folder" save to specific folder in vault
   // folder == "./folder" save to specific subfolder of current active folder
   if (folder && folder.startsWith("./")) {
-    // folder relative to current file
-    const activeFileFolder = `${splitFolderAndFilename(activeViewFilePath).folderpath}/`;
-    folder = normalizePath(activeFileFolder + folder.substring(2));
+    folder = getCurrentActiveDirectory(activeViewFilePath, folder);
   }
   if (!folder || folder === "/") {
     folder = "";
@@ -183,6 +181,15 @@ export const getAttachmentsFolderAndFilePath = async (
       folder === "" ? newFileName : `${folder}/${newFileName}`
     ),
   };
+};
+
+export const getCurrentActiveDirectory =(
+    activeViewFilePath: string,
+    folder: string
+) : string => {
+    // folder relative to current file
+    const activeFileFolder = `${splitFolderAndFilename(activeViewFilePath).folderpath}/`;
+    return normalizePath(activeFileFolder + folder.substring(2));
 };
 
 export const isObsidianThemeDark = () => document.body.classList.contains("theme-dark");


### PR DESCRIPTION
Addresses #1348. 

Adds the ability to specifying saving new drawings into the current folder or a folder within the current folder. I see the above issue when I wanted to see if it was possible to save drawings into the current folder. I wanted to the ability to have my excalidraws in the current folder (or subfolder) of my active note while being able to separate it from my attachments which I have in a folder at the vault root.

![image](https://github.com/zsviczian/obsidian-excalidraw-plugin/assets/12095647/b0630149-4047-4dcb-ae19-33af1c2e0108)

I used the `getAttachmentsFolderAndFilePath()` in ObsidianUtils.ts as reference for handling the various folder options that `app.vault.getConfig("attachmentFolderPath")` returns. 

Since the current logic currently allows saving new drawings to a folder in the vault root or directly to the vault root, the "./" and the "./folder" options is what is being added in this PR. 

"Use Excalidraw folder when embedding a drawing into the active document" will have to be set to **ON** or else it will use the attachments folder set in Obsidian Settings:
- If the Excalidraw Folder is set to "./", new drawings will be saved to the same folder as the current active note.
- If the Excalidraw Folder is set to "./{folder}", new drawings will be saved to a folder (will create if doesn't exist) in the current folder as the current active note.