### PR TITLE
support for tags.

### DIFF
--- a/src/ExcalidrawAutomate.ts
+++ b/src/ExcalidrawAutomate.ts
@@ -761,6 +761,20 @@ export class ExcalidrawAutomate {
           }
         }
       })
+
+      /*ymjr*/
+      outString += "## Tags\n";
+      const tagElements = this.getElements().filter(el => el?.customData?.tags);
+      const tagSet = new Set()
+      for (const el of tagElements) {
+        for (const tag of el.customData.tags) {
+          tagSet.add(tag)
+        }
+      }
+      for (const tag of tagSet) {
+        outString += `${tag}\n\n`;
+      }
+
       return outString + "\n%%\n";
     }
 

--- a/src/ExcalidrawData.ts
+++ b/src/ExcalidrawData.ts
@@ -1320,6 +1320,20 @@ export class ExcalidrawData {
     }
     outString += this.equations.size > 0 || this.files.size > 0 ? "\n" : "";
 
+    outString += "## Tags\n";
+    const tagElements = this.scene.elements.filter((el: ExcalidrawElement) => el?.customData?.tags);
+    const tagSet = new Set();
+    for (const el of tagElements) {
+      for (const tag of el.customData.tags) {
+        if (tag) {
+          tagSet.add(tag)
+        }
+      }
+    }
+    for (const tag of tagSet) {
+      outString += `#${tag}\n\n`;
+    }
+
     const sceneJSONstring = JSON.stringify({
       type: this.scene.type,
       version: this.scene.version,

--- a/src/ExcalidrawView.ts
+++ b/src/ExcalidrawView.ts
@@ -5023,7 +5023,15 @@ export default class ExcalidrawView extends TextFileView {
       elements.filter((el: ExcalidrawElement) => el.type === "frame"),
       query,
       exactMatch
-    ));
+    )).concat(((tagElements: ExcalidrawElement[]): ExcalidrawElement[] => {
+      return tagElements.filter(el => {
+        return query.some(q => {
+          return el.customData.tags.some((e: string) => {
+            return e == q.substring(1)
+          })
+        })
+      });
+    })(elements.filter(el => el?.customData?.tags)));
 
     if (match.length === 0) {
       new Notice("I could not find a matching text element");
@@ -5114,7 +5122,7 @@ export default class ExcalidrawView extends TextFileView {
     if(elements.length === 2) {
       const textEl = elements.filter(el=>el.type==="text");
       if(textEl.length===1 && (textEl[0] as ExcalidrawTextElement).containerId) {
-        const container = elements.filter(el=>el.boundElements.some(be=>be.type==="text"))
+        const container = elements.filter(el=>el?.boundElements?.some?.(be=>be.type==="text"))
         if(container.length===1) {
           elementId = textEl[0].id;
         }


### PR DESCRIPTION
Add a subheading "## Tags" under "# Excalidraw Data" to store tags for elements (element.customData.tags). 

Make it compatible with Obsidian's tag system, so that elements can be searched based on the tags added to them. 

Additionally, when a tag is clicked, the focus should be directed to the corresponding elements with that tag.

![PixPin_2024-05-22_18-55-57](https://github.com/zsviczian/obsidian-excalidraw-plugin/assets/120435922/c9b1fc5b-172d-4b1f-a8cd-df371caaa027)
![PixPin_2024-05-22_18-56-14](https://github.com/zsviczian/obsidian-excalidraw-plugin/assets/120435922/b292c5e1-1aee-4db1-b51f-86b8e3ebaca1)
![PixPin_2024-05-22_18-56-29](https://github.com/zsviczian/obsidian-excalidraw-plugin/assets/120435922/b73d78cf-df68-44d4-b387-027319789923)
