### PR TITLE
Remove autosaveInterval variable but preserve functionality

### DIFF
--- a/src/ExcalidrawView.ts
+++ b/src/ExcalidrawView.ts
@@ -1530,11 +1530,13 @@ export default class ExcalidrawView extends TextFileView {
   public autosaveFunction: Function;
   public setupAutosaveTimer() {
     (process.env.NODE_ENV === 'development') && DEBUGGING && debug(this.setupAutosaveTimer, "ExcalidrawView.setupAutosaveTimer");
+    const autosaveInterval = DEVICE.isMobile ? this.plugin.settings.autosaveIntervalMobile : this.plugin.settings.autosaveIntervalDesktop;
+
     const timer = async () => {
       if(!this.isLoaded) {
         this.autosaveTimer = setTimeout(
           timer,
-          this.plugin.settings.autosaveInterval,
+          autosaveInterval,
         );
         return;
       }
@@ -1569,7 +1571,7 @@ export default class ExcalidrawView extends TextFileView {
         } 
         this.autosaveTimer = setTimeout(
           timer,
-          this.plugin.settings.autosaveInterval,
+          autosaveInterval,
         );
       } else {
         this.autosaveTimer = setTimeout(
@@ -1578,7 +1580,7 @@ export default class ExcalidrawView extends TextFileView {
             this.semaphores.dirty &&
             this.plugin.settings.autosave
             ? 1000 //try again in 1 second
-            : this.plugin.settings.autosaveInterval,
+            : autosaveInterval,
         );
       }
     };

--- a/src/main.ts
+++ b/src/main.ts
@@ -3122,9 +3122,6 @@ export default class ExcalidrawPlugin extends Plugin {
     }
     if(opts.applyLefthandedMode) setLeftHandedMode(this.settings.isLeftHanded);
     if(opts.reEnableAutosave) this.settings.autosave = true;
-    this.settings.autosaveInterval = DEVICE.isMobile
-      ? this.settings.autosaveIntervalMobile
-      : this.settings.autosaveIntervalDesktop;
     setDebugging(this.settings.isDebugMode);
   }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -48,7 +48,6 @@ export interface ExcalidrawSettings {
   decompressForMDView: boolean;
   onceOffCompressFlagReset: boolean; //used to reset compress to true in 2.2.0
   autosave: boolean;
-  autosaveInterval: number;
   autosaveIntervalDesktop: number;
   autosaveIntervalMobile: number;
   drawingFilenamePrefix: string;
@@ -210,7 +209,6 @@ export const DEFAULT_SETTINGS: ExcalidrawSettings = {
   decompressForMDView: false,
   onceOffCompressFlagReset: false,
   autosave: true,
-  autosaveInterval: 15000,
   autosaveIntervalDesktop: 15000,
   autosaveIntervalMobile: 10000,
   drawingFilenamePrefix: "Drawing ",
@@ -699,9 +697,6 @@ export class ExcalidrawSettingTab extends PluginSettingTab {
         .setValue(this.plugin.settings.autosaveIntervalDesktop.toString())
         .onChange(async (value) => {
           this.plugin.settings.autosaveIntervalDesktop = parseInt(value);
-          this.plugin.settings.autosaveInterval = DEVICE.isMobile
-            ? this.plugin.settings.autosaveIntervalMobile
-            : this.plugin.settings.autosaveIntervalDesktop;
           this.applySettingsUpdate();
         }),
     );
@@ -718,9 +713,6 @@ export class ExcalidrawSettingTab extends PluginSettingTab {
         .setValue(this.plugin.settings.autosaveIntervalMobile.toString())
         .onChange(async (value) => {
           this.plugin.settings.autosaveIntervalMobile = parseInt(value);
-          this.plugin.settings.autosaveInterval = DEVICE.isMobile
-            ? this.plugin.settings.autosaveIntervalMobile
-            : this.plugin.settings.autosaveIntervalDesktop;
           this.applySettingsUpdate();
         }),
     );


### PR DESCRIPTION
I've removed the `autosaveInterval` variable from the settings interface, and within the timer function setup a local variable set to the appropriate mobile or desktop version of the variable. 
