### PR TITLE
Documentation: Update Custom Pens documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Drag the desired file from the Obsidian file explorer and hold down <kbd>SHIFT</
 - In plugin settings, you can add a custom fourth font. For more details, see this [video](https://youtu.be/eKFmrSQhFA4)
 - The plugin includes OCR support using Taskbone OCR. For more details, see this [video](https://youtu.be/7gu4ETx7zro)
 - You can convert SVG files into Excalidraw drawings (with some limitation). For more details, see this [video](https://youtu.be/vlC1-iBvIfo)
-- You can define custom pens and higlighters and pin them to the sidebar. For more details, see this [video](https://youtu.be/OjNhjaH2KjI). Using ExcalidrawAutomate, you can add support for (auto-toggling)[ea-scripts/Auto Draw for Pen.md) pen & support for [hardware eraser buttons](ea-scripts/Hardware Eraser Support.md).
+- You can define custom pens and higlighters and pin them to the sidebar. For more details, see this [video](https://youtu.be/OjNhjaH2KjI). Using ExcalidrawAutomate, you can add support for [auto-toggling](<ea-scripts/Auto Draw for Pen.md>) pen & support for [hardware eraser buttons](<ea-scripts/Hardware Eraser Support.md>).
 
 ### Script Engine
 

--- a/README.md
+++ b/README.md
@@ -243,11 +243,11 @@ Drag the desired file from the Obsidian file explorer and hold down <kbd>SHIFT</
 - In plugin settings, you can add a custom fourth font. For more details, see this [video](https://youtu.be/eKFmrSQhFA4)
 - The plugin includes OCR support using Taskbone OCR. For more details, see this [video](https://youtu.be/7gu4ETx7zro)
 - You can convert SVG files into Excalidraw drawings (with some limitation). For more details, see this [video](https://youtu.be/vlC1-iBvIfo)
-- You can define custom freedraw pens. See documentation [here].(https://github.com/zsviczian/obsidian-excalidraw-plugin/blob/master/ea-scripts/Alternative%20Pens.md), [video](https://youtu.be/uZz5MgzWXiM)
+- You can define custom pens and higlighters and pin them to the sidebar. For more details, see this [video](https://youtu.be/OjNhjaH2KjI). Using ExcalidrawAutomate, you can add support for (auto-toggling)[ea-scripts/Auto Draw for Pen.md) pen & support for [hardware eraser buttons](ea-scripts/Hardware Eraser Support.md).
 
 ### Script Engine
 
-- Since 1.5.0, you can easily execute ExcalidrawAutomate macros and assign command palette shortcuts to them, using the ScriptEngine. You will find an intro video and a growing library of ready to install scripts [here](https://github.com/zsviczian/obsidian-excalidraw-plugin/tree/master/ea-scripts).
+- Since 1.5.0, you can easily execute ExcalidrawAutomate macros and assign command palette shortcuts to them, using the ScriptEngine. You will find an intro video and a growing library of ready to install scripts [here](ea-scripts/README.md).
 - You can organize scripts into groups on the Obsidian Tools Panel in Excalidraw by moving scripts and accompanying SVG icon files to folders. See the demo [video](https://youtu.be/wTtaXmRJ7wg?t=16).
 
 ### Other


### PR DESCRIPTION
**Issue:**
- The README contains a broken link to a not-on-main file documenting how to add custom pens. (That document was archived.) 
- The README hard-links to the master branch of the EA folder rather than to whatever branch the GH user is on. I have made that link relative, so that when looking at a different branch, the links are relative to the branch the user is searching around on.

**Fix:**
- Pens are now handled in settings with a different YouTube video showing how to set them up (I think). 
- Adds links to the Hardware Eraser functionality & Auto Draw for Pen. 

Open Question/Discussion:
- I think it might be useful to link to the freestyle docs here still, or have some sort of master "Alternative Pens" link that still shows how to do the JSON setup as opposed to the UI setup? Not sure if necessary? 
- In terms of pen setup docs, I just see issue #986 (with its screenshot) and of course the video setup. I'm still a beginner on Obsidian stuff but am open to help with writing up some more of the docs that are in YT videos, if that would be helpful to you.

Thanks for all your work! Please let me know if I can answer any questions!