### PR TITLE
Update ExcaliAI.md to fix incorrect request json for openai api

### DIFF
--- a/ea-scripts/ExcaliAI.md
+++ b/ea-scripts/ExcaliAI.md
@@ -427,7 +427,7 @@ const run = async (text) => {
   
   const requestObject = isImageEditRequest
   ? {
-      ...imageDataURL ? {image: imageDataURL} : {},
+      ...imageDataURL ? {image: {url: imageDataURL}} : {},
       ...(text && text.trim() !== "") ? {text} : {},
       imageGenerationProperties: {
         size: imageSize, 
@@ -437,7 +437,7 @@ const run = async (text) => {
       },
     }
   : {
-      ...imageDataURL ? {image: imageDataURL} : {},
+      ...imageDataURL ? {image: {url: imageDataURL}} : {},
       ...(text && text.trim() !== "") ? {text} : {},
       systemPrompt: systemPrompt.prompt,
       instruction: outputType.instruction,


### PR DESCRIPTION
Right now I am getting this error when trying to use ExcaliAI when an image is selected.
<img src="https://github.com/zsviczian/obsidian-excalidraw-plugin/assets/5645636/1bbc07a8-2046-4545-a6d2-e652d13cee2f" width="200">

This PR updates request json from `{image: imageDataURL}` to `{image: {url: imageDataURL}}`
