### PR TITLE
Fix `authorUrl` in manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "minAppVersion": "1.1.6",
   "description": "An Obsidian plugin to edit and view Excalidraw drawings",
   "author": "Zsolt Viczian",
-  "authorUrl": "https://zsolt.blog",
+  "authorUrl": "https://www.zsolt.blog",
   "fundingUrl": "https://ko-fi.com/zsolt",
   "helpUrl": "https://github.com/zsviczian/obsidian-excalidraw-plugin#readme",
   "isDesktopOnly": false


### PR DESCRIPTION
I noticed that the `authorUrl` in the manifest does not work, as it's missing the `www`.

![image](https://github.com/user-attachments/assets/135fed9d-7c9d-4119-96fd-ddff2846607b)
