### PR TITLE
Fix an issue with my Windows Pen scripts

### DIFF
--- a/ea-scripts/Auto Draw for Pen.md
+++ b/ea-scripts/Auto Draw for Pen.md
@@ -12,6 +12,8 @@ Compatible with my *Hardware Eraser Support* script
 
 ```javascript
 */
+let eaGlobal = ea
+
 (function() {
     'use strict';
     
@@ -20,10 +22,10 @@ Compatible with my *Hardware Eraser Support* script
     let disable
 
     function handlePointer(e) {
-        ea.setView("active");
-        var activeTool = ea.getExcalidrawAPI().getAppState().activeTool;
+        eaGlobal.setView("active");
+        var activeTool = eaGlobal.getExcalidrawAPI().getAppState().activeTool;
         function setActiveTool(t) {
-            ea.getExcalidrawAPI().setActiveTool(t)
+            eaGlobal.getExcalidrawAPI().setActiveTool(t)
         }
 
         if (e.pointerType === 'pen') {
@@ -32,7 +34,7 @@ Compatible with my *Hardware Eraser Support* script
                 setActiveTool({type:"freedraw"})
             }
 
-            if (timeout) clearTimeout(timeout)
+            if (timeout) cleaGlobalrTimeout(timeout)
 
             function setTimeoutX(a,b) {
                 timeout = setTimeout(a,b)
@@ -40,7 +42,7 @@ Compatible with my *Hardware Eraser Support* script
             }
     
             function revert() {
-                activeTool = ea.getExcalidrawAPI().getAppState().activeTool;
+                activeTool = eaGlobal.getExcalidrawAPI().getAppState().activeTool;
                 disable = false
                 if (activeTool.type==='freedraw') {
                     setActiveTool({type:"selection"})
@@ -55,7 +57,7 @@ Compatible with my *Hardware Eraser Support* script
         }
     }
     function handleClick(e) {
-        ea.setView("active");
+        eaGlobal.setView("active");
         if (e.pointerType !== 'pen') {
             disable = false
         }

--- a/ea-scripts/Hardware Eraser Support.md
+++ b/ea-scripts/Hardware Eraser Support.md
@@ -11,6 +11,8 @@ Compatible with my *Auto Draw for Pen* script
 ```javascript
 */
 
+let eaGlobal = ea
+
 (function() {
     'use strict';
 
@@ -18,12 +20,16 @@ Compatible with my *Auto Draw for Pen* script
     let revert
     
     function handlePointer(e) {
-        const activeTool = ea.getExcalidrawAPI().getAppState().activeTool;
+        const activeTool = eaGlobal.getExcalidrawAPI().getAppState().activeTool
         const isEraser = e.pointerType === 'pen' && e.buttons & 32
         function setActiveTool(t) {
-            ea.getExcalidrawAPI().setActiveTool(t)
+            eaGlobal.getExcalidrawAPI().setActiveTool(t)
         }
         if (!activated && isEraser) {
+            if (activeTool.type == "eraser") {
+                //console.log("Multiple instances running, cancelled this one")
+                return
+            } 
             //Store previous tool
             const btns = document.querySelectorAll('.App-toolbar input.ToolIcon_type_radio')
             for (const i in btns) {
@@ -47,26 +53,29 @@ Compatible with my *Auto Draw for Pen* script
         // Keep on eraser!
         if (isEraser && activated) {
             setActiveTool({type: "eraser"})
+            Object.defineProperty(e, 'button', {
+                value: 0,
+                writable: false
+            });
         }
         if (activated && !isEraser) {
-            // Revert tool on release
-            // revert.click()
+            // Revert tool on releaGlobalse
             setActiveTool(revert)
             activated = false
-            
             // Force delete "limbo" elements
             // This doesn't happen on the web app
             // It's a bug caused by switching to eraser during a stroke
-            ea.setView("active");
+            eaGlobal.setView("active");
             var del = []
-            for (const i in ea.getViewElements()) {
-                const element = ea.getViewElements()[i];
+            for (const i in eaGlobal.getViewElements()) {
+                const element = eaGlobal.getViewElements()[i];
                 if (element.opacity === 20) {
                     del.push(element)
                 }
             }
-            ea.deleteViewElements(del)
+            eaGlobal.deleteViewElements(del)
             setActiveTool(revert)
+    
         }
     }
     


### PR DESCRIPTION
These scripts are special because they run persistently, but they still reference Excalidraw-Automate using the ea variable. Running them again previously did nothing.

As of some update, the ea variable becomes stale if excalidraw is closed and reopened, and can no longer be successfully referenced. This caused some issues with these scripts.

I've updated them to use a new global variable `eaGlobal` which is set when either script is run, even if an instance is already running. If you reopen excalidraw, you'll *may* get the same issues, but they'll be resolved when either script is run again.