### PR TITLE
Allow poorly formated .excalidraw files to render 

### DIFF
--- a/src/ExcalidrawData.ts
+++ b/src/ExcalidrawData.ts
@@ -518,7 +518,7 @@ export class ExcalidrawData {
       return;
     }
 
-    const saveVersion = this.scene.source.split("https://github.com/zsviczian/obsidian-excalidraw-plugin/releases/tag/")[1]??"1.8.16";
+    const saveVersion = this.scene.source?.split("https://github.com/zsviczian/obsidian-excalidraw-plugin/releases/tag/")[1]??"1.8.16";
 
     const elements = this.scene.elements;
     for (const el of elements) {


### PR DESCRIPTION
The Excalidraw [JSON schema](https://docs.excalidraw.com/docs/codebase/json-schema) clearly requires the `source` property, but some Excalidraw implementations do not include this.

In the case of Nextcloud Whiteboard, which does not include the `source` property in its Excalidraw JSON, causes this plugin to hang when trying to render the drawing in legacy mode.

This PR uses the optional chaining (?.) feature of JS to gracefully accept a missing `source` property.

