### PR TITLE
Allow custom location for LaTeX preamble file and small fix

### DIFF
--- a/MathjaxToSVG/index.ts
+++ b/MathjaxToSVG/index.ts
@@ -69,7 +69,7 @@ export async function tex2dataURL(
 
   try {
     const node = html.convert(
-      preamble ? `${preamble}${tex}` : tex,
+      preamble ? `${preamble}\n${tex}` : tex,
       { display: true, scale }
     );
     const svg = new DOMParser().parseFromString(adaptor.innerHTML(node), "image/svg+xml").firstChild as SVGSVGElement;

--- a/MathjaxToSVG/index.ts
+++ b/MathjaxToSVG/index.ts
@@ -38,7 +38,7 @@ async function getImageSize(src: string): Promise<{ height: number; width: numbe
 export async function tex2dataURL(
   tex: string,
   scale: number = 4,
-  app?: any
+  plugin?: any
 ): Promise<{
   mimeType: string;
   fileId: FileId;
@@ -50,9 +50,9 @@ export async function tex2dataURL(
   let output: SVG<unknown, unknown, unknown>;
 
   if(!adaptor) {
-    if (app) {
-      const file = app.vault.getAbstractFileByPath("preamble.sty");
-      preamble = file ? await app.vault.read(file) : null;
+    if (plugin) {
+      const file = plugin.app.vault.getAbstractFileByPath(plugin.settings.latexPreambleLocation || "preamble.sty");
+      preamble = file ? await plugin.app.vault.read(file) : null;
     }
     adaptor = liteAdaptor();
     RegisterHTMLHandler(adaptor);

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -173,6 +173,7 @@ export interface ExcalidrawSettings {
   showNewVersionNotification: boolean;
   //mathjaxSourceURL: string;
   latexBoilerplate: string;
+  latexPreambleLocation: string;
   taskboneEnabled: boolean;
   taskboneAPIkey: string;
   pinnedScripts: string[];
@@ -348,6 +349,7 @@ export const DEFAULT_SETTINGS: ExcalidrawSettings = {
   showNewVersionNotification: true,
   //mathjaxSourceURL: "https://cdn.jsdelivr.net/npm/mathjax@3.2.1/es5/tex-svg.js",
   latexBoilerplate: "\\color{blue}",
+  latexPreambleLocation: "preamble.sty",
   taskboneEnabled: false,
   taskboneAPIkey: "",
   pinnedScripts: [],
@@ -2613,6 +2615,19 @@ export class ExcalidrawSettingTab extends PluginSettingTab {
           .setValue(this.plugin.settings.latexBoilerplate)
           .onChange( (value) => {
             this.plugin.settings.latexBoilerplate = value;
+            this.applySettingsUpdate();
+          }),
+      );
+
+	new Setting(detailsEl)
+      .setName(t("LATEX_PREAMBLE_NAME"))
+      .setDesc(fragWithHTML(t("LATEX_PREAMBLE_DESC")))
+      .addText((text) =>
+        text
+	  	  .setPlaceholder("e.g.: preamble.sty")
+          .setValue(this.plugin.settings.latexPreambleLocation)
+          .onChange(async (value) => {
+            this.plugin.settings.latexPreambleLocation = value;
             this.applySettingsUpdate();
           }),
       );

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -722,6 +722,8 @@ FILENAME_HEAD: "Filename",
     "restart Obsidian after closing settings, for this change to take effect.",
   LATEX_DEFAULT_NAME: "Default LaTeX formula for new equations",
   LATEX_DEFAULT_DESC: "Leave empty if you don't want a default formula. You can add default formatting here such as <code>\\color{white}</code>.",
+  LATEX_PREAMBLE_NAME: "LaTeX preamble file (CasE SEnSiTivE!)",
+  LATEX_PREAMBLE_DESC: "Full filepath to the preamble file, leave empty for default. If the file doesn't exist this option will be ignored.<br><strong>Important:</strong> Requires obsidian reload after change to take effect!",
   NONSTANDARD_HEAD: "Non-Excalidraw.com supported features",
   NONSTANDARD_DESC: `These settings in the "Non-Excalidraw.com Supported Features" section provide customization options beyond the default Excalidraw.com features. These features are not available on excalidraw.com. When exporting the drawing to Excalidraw.com these features will appear different.
     You can configure the number of custom pens displayed next to the Obsidian Menu on the canvas, allowing you to choose from a range of options. Additionally, you can enable a local font option, which adds a local font to the list of fonts on the element properties panel for text elements. `,

--- a/src/shared/EmbeddedFileLoader.ts
+++ b/src/shared/EmbeddedFileLoader.ts
@@ -704,7 +704,7 @@ export class EmbeddedFilesLoader {
           }
           if (!excalidrawData.getEquation(id).isLoaded) {
             const latex = equation.latex;
-            const data = await tex2dataURL(latex, 4, this.plugin.app);
+            const data = await tex2dataURL(latex, 4, this.plugin);
             if (data) {
               const fileData = {
                 mimeType: data.mimeType,

--- a/src/shared/ExcalidrawAutomate.ts
+++ b/src/shared/ExcalidrawAutomate.ts
@@ -1848,7 +1848,7 @@ export class ExcalidrawAutomate {
    */
   async addLaTex(topX: number, topY: number, tex: string): Promise<string> {
     const id = nanoid();
-    const image = await tex2dataURL(tex, 4, this.plugin.app);
+    const image = await tex2dataURL(tex, 4, this.plugin);
     if (!image) {
       return null;
     }
@@ -1890,7 +1890,7 @@ export class ExcalidrawAutomate {
     created: number;
     size: { height: number; width: number };
   }> {
-    return await tex2dataURL(tex,scale, this.plugin.app);
+    return await tex2dataURL(tex,scale, this.plugin);
   };
 
   /**

--- a/src/shared/LaTeX.ts
+++ b/src/shared/LaTeX.ts
@@ -3,7 +3,7 @@ import { DataURL } from "@zsviczian/excalidraw/types/excalidraw/types";
 import ExcalidrawView from "../view/ExcalidrawView";
 import { FileData, MimeType } from "./EmbeddedFileLoader";
 import { FileId } from "@zsviczian/excalidraw/types/excalidraw/element/types";
-import { App } from "obsidian";
+import ExcalidrawPlugin from "src/core/main";
 
 declare const loadMathjaxToSVG: Function;
 let mathjaxLoaded = false;
@@ -52,7 +52,7 @@ export const updateEquation = async (
 export async function tex2dataURL(
   tex: string,
   scale: number = 4,
-  app: App,
+  plugin: ExcalidrawPlugin,
 ): Promise<{
   mimeType: MimeType;
   fileId: FileId;
@@ -61,7 +61,7 @@ export async function tex2dataURL(
   size: { height: number; width: number };
 }> {
   await loadMathJax();
-  return tex2dataURLExternal(tex, scale, app);
+  return tex2dataURLExternal(tex, scale, plugin);
 }
 
 export const clearMathJaxVariables = () => {


### PR DESCRIPTION
Added the option to specify a custom location for the preamble file, leaving the default for backward compatibility.
Fixes #1631 separating the preamble and the inserted latex with a `\n`.