### PR TITLE
Enhance Connect Elements script: auto-select arrows after creation 

### DIFF
--- a/ea-scripts/Connect elements.md
+++ b/ea-scripts/Connect elements.md
@@ -79,3 +79,5 @@ ea.connectObjects(
   }
 );
 ea.addElementsToView(false,false,true);
+const ids = ea.getElements().map(el=>el.id);
+ea.selectElementsInView(ea.getViewElements().filter(el=>ids.contains(el.id)));

--- a/ea-scripts/Connect elements.md
+++ b/ea-scripts/Connect elements.md
@@ -78,6 +78,6 @@ ea.connectObjects(
 	numberOfPoints: linePoints
   }
 );
-ea.addElementsToView(false,false,true);
+await ea.addElementsToView(false,false,true);
 const ids = ea.getElements().map(el=>el.id);
 ea.selectElementsInView(ea.getViewElements().filter(el=>ids.contains(el.id)));


### PR DESCRIPTION
## Summary

This PR updates the `Connect elements` script to automatically select the newly created connector arrow(s) after running the script. It improves workflow by allowing users to immediately manipulate or inspect the arrow(s) (e.g., for styling or deleting), **so reverse the arrows will easier**.

## Changes

- Added `ea.addElementsToView(false,false,true)` to flush view updates
- Captured the current set of all element IDs after insertion
- Selected arrow elements via `ea.selectElementsInView(...)` using ID filter

## Motivation

Currently, the script creates arrows but does not visually select them. This change adds a minor UX improvement by reducing the number of manual clicks after connecting elements.

## Compatibility

- Tested with plugin version 1.9.27
- No breaking changes
- Fallbacks retained for group detection logic

## Related

- Based on documentation: https://zsviczian.github.io/obsidian-excalidraw-plugin/ExcalidrawScriptsEngine.html
- Discussed in user request about selecting created elements after `connectObjects`