### PR TITLE
Update Box Selected Elements.md with round ness

### DIFF
--- a/ea-scripts/Box Selected Elements.md
+++ b/ea-scripts/Box Selected Elements.md
@@ -44,6 +44,7 @@ color = ea
 //uncomment for random color:
 //color = '#'+(Math.random()*0xFFFFFF<<0).toString(16).padStart(6,"0");
 ea.style.strokeColor = color;
+ea.style.roundness = {type: 3, value:32};
 id = ea.addRect(
 	box.topX - padding,
 	box.topY - padding,


### PR DESCRIPTION
I use the round boxes so and i was able to change this to make it work for me. I was wondering if there wsas a way to get the roundness property similar to how the color was derived from the API. 
color = ea
        .getExcalidrawAPI()
        .getAppState()
        .currentItemStrokeColor;
//uncomment for random color:
//color = '#'+(Math.random()*0xFFFFFF<<0).toString(16).padStart(6,"0");
ea.style.strokeColor = color;

How can we do this for roundness