### PR TITLE
feat: add basic drawing tools to palm guard Floating Modal

### DIFF
--- a/ea-scripts/Palm Guard.md
+++ b/ea-scripts/Palm Guard.md
@@ -25,6 +25,7 @@ async function run() {
     window.excalidrawPalmGuard()
     return;
   }
+  const excalidrawAPI = ea.getExcalidrawAPI()
   const modal = new ea.FloatingModal(ea.plugin.app);
   const FULLSCREEN = "Goto fullscreen?";
   let settings = ea.getScriptSettings() || {};
@@ -46,12 +47,12 @@ async function run() {
 
   // Initialize state
   let uiHidden = true;
+  let unsuscribeOnChange = () => {}
   let currentIcon = "eye";
   let layerUIWrapper = ea.targetView.contentEl.querySelector(".excalidraw.excalidraw-container > .layer-ui__wrapper");
   const toolbar = ea.targetView.contentEl.querySelector(".excalidraw > .Island");
   let toolbarActive = toolbar?.style.display === "block";
   let prevHiddenState = false;
-  
   // Function to toggle UI visibility
   const toggleUIVisibility = (hidden) => {
     if(hidden === prevHiddenState) return hidden;
@@ -67,7 +68,6 @@ async function run() {
     } else {
       try{
         const topBar = ea.targetView.containerEl.querySelector(".App-top-bar");
-        const bottomBar = ea.targetView.containerEl.querySelector(".App-bottom-bar");
         const sidebarToggle = ea.targetView.containerEl.querySelector(".sidebar-toggle");
         const plugins = ea.targetView.containerEl.querySelector(".plugins-container");
   
@@ -83,7 +83,6 @@ async function run() {
         const display = hidden ? "none" : "";
         
         if (topBar) topBar.style.display = display;
-        if (bottomBar) bottomBar.style.display = display;
         if (sidebarToggle) sidebarToggle.style.display = display;
         if (plugins) plugins.style.display = display;
         if (toolbarActive) toolbar.style.display = hidden ? "none" : "block";
@@ -104,9 +103,9 @@ async function run() {
     height: "fit-content",
     minHeight: "fit-content",
     paddingBottom: "4px",
-    paddingTop: "16px",
-    paddingRight: "4px",
-    paddingLeft: "4px"
+    paddingTop: "4px",
+    paddingRight: "8px",
+    paddingLeft: "8px"
   });
   
   modal.headerEl.style.display = "none";
@@ -130,12 +129,12 @@ async function run() {
     
     // Toggle UI visibility button
     const toggleButton = buttonContainer.createEl("button", {
-      cls: "palm-guard-btn clickable-icon",
+      cls: "palm-guard-btn clickable-icon cpg-button-toggled-off",
       attr: { 
         style: "background-color: var(--interactive-accent); color: var(--text-on-accent);" 
       }
     });
-    toggleButton.innerHTML = ea.obsidian.getIcon("eye").outerHTML;
+    toggleButton.innerHTML = ea.obsidian.getIcon("eye-off").outerHTML;
     // Keyboard hotkey listener (only acts if hotkey configured)
     window.excalidrawPalmGuard = () => toggleButton.click();
     toggleButton.addEventListener("click", () => {
@@ -143,9 +142,127 @@ async function run() {
       toggleUIVisibility(uiHidden);
       
       // Toggle icon
-      currentIcon = uiHidden ? "eye" : "eye-off";
+      currentIcon = uiHidden ? "eye-off" : "eye" ;
+      if (toggleButton.classList.contains('cpg-button-toggled-on')) {
+        toggleButton.classList.remove('cpg-button-toggled-on');
+        toggleButton.classList.add('cpg-button-toggled-off');
+        
+      } else {
+        toggleButton.classList.remove('cpg-button-toggled-off');
+        toggleButton.classList.add('cpg-button-toggled-on');
+      }
+
       toggleButton.innerHTML = ea.obsidian.getIcon(currentIcon).outerHTML;
     });
+
+    // ===================== CUSTOM BUTTONS =====================
+
+      // Function to toggle between cpg-button-toggled-on and cpg-button-toggled-off
+    const toggleButtonVisibleStateClass = (customToolsToggle, selectedTool) => {
+
+      const toolButton = customToolsToggle[selectedTool];
+      if (toolButton.classList.contains('cpg-button-toggled-off')) {
+        toolButton.classList.remove('cpg-button-toggled-off');
+        toolButton.classList.add('cpg-button-toggled-on');
+        
+        Object.values(customToolsToggle).forEach(nonSelectedTool => {
+          if (nonSelectedTool != toolButton) {
+            nonSelectedTool.classList.remove('cpg-button-toggled-on');
+            nonSelectedTool.classList.add('cpg-button-toggled-off');
+          }
+        })
+      }
+    }
+
+    const getActiveTool = (excalidrawAPI) => {
+      const state = excalidrawAPI.getAppState();
+      return state?.activeTool?.type;
+    }
+
+    const setActiveTool = (excalidrawAPI, selectedTool) => {
+      const toolType = { type: selectedTool };
+      excalidrawAPI.setActiveTool(toolType);
+      toggleButtonVisibleStateClass(customToolsToggle, selectedTool);
+    }
+
+    let currentTool = undefined;
+    // Select Tool Button
+    const selectToolButton = buttonContainer.createEl("button", {
+      cls: "palm-guard-btn clickable-icon cpg-button-toggled-off",
+      attr: { 
+        style: "background-color: var(--interactive-accent); color: var(--text-on-accent);" 
+      }
+    });
+    selectToolButton.innerHTML = ea.obsidian.getIcon("mouse-pointer").outerHTML;
+    selectToolButton.addEventListener("click", () => {
+      currentTool = 'selection';
+      setActiveTool(excalidrawAPI, currentTool);
+    });
+
+    // Pencil Tool Button
+    const pencilToolButton = buttonContainer.createEl("button", {
+      cls: "palm-guard-btn clickable-icon cpg-button-toggled-off",
+      attr: { 
+        style: "background-color: var(--interactive-accent); color: var(--text-on-accent);" 
+      }
+    });
+    
+    pencilToolButton.innerHTML = ea.obsidian.getIcon("pencil").outerHTML;
+    pencilToolButton.addEventListener("click", () => {
+      currentTool = 'freedraw';
+      setActiveTool(excalidrawAPI, currentTool);
+    });
+
+    // eraser Tool Button
+    const eraserToolButton = buttonContainer.createEl("button", {
+      cls: "palm-guard-btn clickable-icon cpg-button-toggled-off",
+      attr: {
+        style: "background-color: var(--interactive-accent); color: var(--text-on-accent);" 
+      }
+    });
+    
+    eraserToolButton.innerHTML = ea.obsidian.getIcon("eraser").outerHTML;
+    eraserToolButton.addEventListener("click", () => {
+      currentTool = 'eraser';
+      setActiveTool(excalidrawAPI, currentTool);
+    });
+
+    // Hand Tool Button
+    const handToolButton = buttonContainer.createEl("button", {
+      cls: "palm-guard-btn clickable-icon cpg-button-toggled-off",
+      attr: {
+        style: "background-color: var(--interactive-accent); color: var(--text-on-accent);" 
+      }
+    });
+    
+    handToolButton.innerHTML = ea.obsidian.getIcon("hand").outerHTML;
+    handToolButton.addEventListener("click", () => {
+      currentTool = 'hand';
+      setActiveTool(excalidrawAPI, currentTool);
+    });
+
+    const customToolsToggle = {
+      selection: selectToolButton,
+      lasso: selectToolButton,
+      hand: handToolButton,
+      freedraw: pencilToolButton,
+      eraser: eraserToolButton,
+    }
+
+    let selectedToolOnRun = getActiveTool(excalidrawAPI);
+    if (customToolsToggle[selectedToolOnRun] != null) {
+      currentTool = selectedToolOnRun
+      toggleButtonVisibleStateClass(customToolsToggle, selectedToolOnRun)
+    }
+
+    unsuscribeOnChange = excalidrawAPI.onChange((e, as, f) => {
+      if (as?.activeTool?.type != null
+          && customToolsToggle[as?.activeTool?.type] != null) {
+          toggleButtonVisibleStateClass(customToolsToggle, as?.activeTool?.type);
+      }
+    })
+
+    // ===================== CUSTOM BUTTONS =====================
     
     // Exit button
     const exitButton = buttonContainer.createEl("button", {
@@ -179,6 +296,14 @@ async function run() {
           height: 2em;
           cursor: pointer;
         }
+
+        .cpg-button-toggled-on {
+          opacity: 0.8;
+        }
+
+        .cpg-button-toggled-off {
+          opacity: 0.4;
+        }
       `
     });
   });
@@ -191,7 +316,9 @@ async function run() {
   modal.onClose = () => {
     // Show all UI elements
     toggleUIVisibility(false);
-    
+    // https://docs.excalidraw.com/docs/@excalidraw/excalidraw/api/props/excalidraw-api#onchange
+    // unsuscribe excalidraw on change
+    unsuscribeOnChange();
     // Exit fullscreen
     if(ea.targetView && enableFullscreen) ea.targetView.exitFullscreen();
     clearInterval(autocloseTimer);
@@ -206,8 +333,13 @@ async function run() {
     const modalEl = modal.modalEl;
     const rect = ea.targetView.contentEl.getBoundingClientRect();
     if (modalEl) {
-      modalEl.style.left = `${rect.left+10}px`;
-      modalEl.style.top = `${rect.top+10}px`;
+      // Adjust positioning based on device type
+      const isTablet = ea.DEVICE.isTablet || ea.DEVICE.isMobile;
+      const leftOffset = 10;
+      const topOffset = isTablet ? 10 : 50;
+      
+      modalEl.style.left = `${rect.left + leftOffset}px`;
+      modalEl.style.top = `${rect.top + topOffset}px`;
     }
   }, 100);
 }


### PR DESCRIPTION
- Added Excalidraw tool buttons to the palm guard Floating Modal for improved accessibility to basic stylus drawing tools.
    - Selection, Pencil, Eraser, and Hand Tools.
- Added UI styles to highlight the current selected tool.
- Toggle eye icon (open/closed) in the Floating Modal when user toggles the palm guard from the Modal.
- Position the Floating Modal position based on the ea.Device API.
- Keep the bottom Excalidraw toolbar always visible (Major Difference).