### PR TITLE
Hide the StatusBar while in an ExcalidrawView

### DIFF
--- a/src/core/managers/EventManager.ts
+++ b/src/core/managers/EventManager.ts
@@ -215,9 +215,15 @@ export class EventManager {
     this.previouslyActiveLeaf = leaf;
     
     if (newActiveviewEV) {
+      // hide the statusBar while in an ExcalidrawView
+      this.app.statusBar.containerEl.hide()
+
       this.plugin.addModalContainerObserver();
       this.plugin.lastActiveExcalidrawFilePath = newActiveviewEV.file?.path;
     } else {
+      // restore the statusBar after unfocusing an ExcalidrawView
+      this.app.statusBar.containerEl.show()
+
       this.plugin.removeModalContainerObserver();
     }
 

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -69,6 +69,9 @@ declare module "obsidian" {
         [key: string]: Plugin | undefined;
       };
     };
+    statusBar: {
+      containerEl: HTMLElement;
+    };
   }
   interface FileManager {
     promptForFileRename(file: TFile): Promise<void>;


### PR DESCRIPTION
Hides the Statusbar while in an ExcalidrawView and restores it upon unfocusing.

Imo, this implementation is quite safe, it might only clash with another Extension, hiding the Statusbar in similar fashion. In that regard, I would suggest toggling a CSS-class, instead of the `HTMLElement::hide()`, yet I'd deem that unnecessary.

I tested these changes on Windows and with the `emulateMobile` functionallity, where I didn't observe any issues.