### PR TITLE
Fix popover image sizing to match embeds more closely

### DIFF
--- a/src/core/managers/MarkdownPostProcessor.ts
+++ b/src/core/managers/MarkdownPostProcessor.ts
@@ -853,6 +853,13 @@ const tmpObsidianWYSIWYG = async (
         imgDiv.firstChild.style.maxHeight = "100%";
         imgDiv.firstChild.style.maxWidth = null;
       }
+      // Resolve the cyclic size dependency by applying a CSS width and/or height
+      if(!onCanvas && isHoverPopover && imgDiv.firstChild instanceof HTMLImageElement) {
+          internalEmbedDiv.style.setProperty("--popover-width", attr.fwidth + "px");
+          internalEmbedDiv.style.setProperty("--popover-height", attr.fheight + "px");
+          internalEmbedDiv.style.width = "var(--popover-width)";
+          internalEmbedDiv.style.height = "var(--popover-height)";
+      }
       internalEmbedDiv.appendChild(imgDiv.firstChild);
       return;
     }


### PR DESCRIPTION
They were not responding to the default width parameter in the settings. Also prior to this if you added a default height, but removed the default width, they would render at 0 width (verified in a brand new vault with only excalidraw installed).

The conditional at the beginning works properly to limit the scope, but I am unsure if it is the cleanest approach.