### PR TITLE
Bug fix: incorrectly-replaced back-of-note

### DIFF
--- a/src/utils/excalidrawViewUtils.ts
+++ b/src/utils/excalidrawViewUtils.ts
@@ -271,12 +271,11 @@ export async function addBackOfTheNoteCard(
   const shouldRemoveTrailingHashtag = Boolean(hastag);
   view.data = data.replace(
     header,
-    (shouldRemoveTrailingHashtag 
+    () => (shouldRemoveTrailingHashtag 
       ? header.substring(0,header.length-hastag[0].length) 
       : header) +
         `\n# ${title}\n\n${cardBody ? cardBody+"\n\n" : ""}${
           shouldAddHashtag || shouldRemoveTrailingHashtag ? "#\n" : ""}`);
-  
   await view.forceSave(true);
   let watchdog = 0;
   await sleep(200);


### PR DESCRIPTION
fix the bug https://github.com/zsviczian/obsidian-excalidraw-plugin/issues/2296

As said in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement 
for some reasons "$$" are replaced by "$" if we give a string as replacement

but they also say that those replacements are not active if we give a replacer function instead
> Note: The above-mentioned special replacement patterns do not apply for strings returned from the replacer function.