### PR TITLE
fix: incorrect import

### DIFF
--- a/src/core/main.ts
+++ b/src/core/main.ts
@@ -97,7 +97,7 @@ import { get } from "http";
 import { getHighlightColor } from "src/utils/dynamicStyling";
 import { InlineLinkSuggester } from "src/shared/Suggesters/InlineLinkSuggester";
 import { KeyBlocker } from "src/types/excalidrawAutomateTypes";
-import { UIMode } from "lib/shared/Dialogs/UIModeSettingComponent";
+import { UIMode } from "src/shared/Dialogs/UIModeSettingComponent";
 
 declare const PLUGIN_VERSION:string;
 declare const INITIAL_TIMESTAMP: number;


### PR DESCRIPTION
Hi,

I'm "maintaining" a [NUR Nix](https://github.com/Ev357/nur-packages/blob/main/pkgs/obsidian-excalidraw-plugin/default.nix) package for this obsidian excalidraw plugin. I like to build all packages from source if possible in the Nix way. I noticed a build failure where it's referencing a non-existing file.

I fixed the import path from `lib` to `src`.

`npm run lib` also does not work with the wrong import.

PS: I also have a problem with the package lock file that appears to be incorrect when running `npm ci`. Let me know if you want me to open an issue.