### PR TITLE
add back latex scale on update

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -593,6 +593,9 @@ export function scaleLoadedImage (
           const elNewWidth = imgWidth * scale.scaleX;
           el.height = elNewHeight;
           el.width = elNewWidth;
+          // we won't need the latexscale anymore
+          // if we don't delete it, it will (maybe wrongfully) scale it back when reloading the view
+          addAppendUpdateCustomData(el, {latexscale : undefined});
         }else if(maintainArea) {
           const elAspectRatio = elWidth / elHeight;
           if (imgAspectRatio !== elAspectRatio) {

--- a/src/view/ExcalidrawView.ts
+++ b/src/view/ExcalidrawView.ts
@@ -1128,6 +1128,12 @@ export default class ExcalidrawView extends TextFileView implements HoverParent{
       const ea = getEA(this) as ExcalidrawAutomate;
       ea.copyViewElementsToEAforEditing([el]);
       ea.addAppendUpdateCustomData(el.id, {latex: formula});
+      const dataurl = await ea.tex2dataURL(equation);
+      if (dataurl && dataurl.size.height > 0 && dataurl.size.width > 0) {
+        ea.addAppendUpdateCustomData(el.id, {
+          latexscale: {scaleX: el.width/dataurl.size.width, scaleY: el.height/dataurl.size.height}
+        });
+      }
       await ea.addElementsToView(false, false, false, false);
       await this.save(false);
       await updateEquation(


### PR DESCRIPTION
add back the latex scaling from https://github.com/zsviczian/obsidian-excalidraw-plugin/pull/2604 that was removed on 2.20.0 (precisely with 03d3e25611208a7990ba90ab32e8d85e46a08ffa)

There was a bug when we:
- update a latex formula
- change his size
- reload the view

Since customData.latexscale was taking the priority and wrongfully scaling it

**Do you agree to delete latexscale after we used it once?** (in `scaleLoadedImage`) I am not sure it's a good place to do it