### PR TITLE
make the latexprompt floating

### DIFF
--- a/src/shared/Dialogs/Prompt.ts
+++ b/src/shared/Dialogs/Prompt.ts
@@ -30,6 +30,7 @@ import { parser } from "./math-only";
 import { LRLanguage } from "@codemirror/language";
 import { editorLivePreviewField } from "obsidian";
 import { Extension } from "@codemirror/state";
+import { FloatingModal } from "./FloatingModal";
 
 export class Prompt extends Modal {
   private promptEl: HTMLInputElement;
@@ -86,7 +87,7 @@ export class Prompt extends Modal {
   }
 }
 
-export class LaTexPrompt extends Modal {
+export class LaTexPrompt extends FloatingModal {
   public waitForClose : Promise<string>;
   private promptEl: HTMLInputElement;
   private resolvePromise: (input: string) => void;
@@ -103,6 +104,7 @@ export class LaTexPrompt extends Modal {
     this.titleEl.setText(this.prompt_text);
     this.contentEl.addClass("excalidraw-LatexPrompt");
     this.latexsSuitePlugin = app.plugins.plugins["obsidian-latex-suite"];
+    super.enableKeyCapture(); // otherwise latex-suite (or Ctrl-Enter) do not get the key event
     const mainContentContainer: HTMLDivElement = this.contentEl.createDiv();
     this.display(default_value, mainContentContainer);
     this.waitForClose = new Promise<string>((resolve, reject) => {
@@ -138,7 +140,7 @@ export class LaTexPrompt extends Modal {
       }]),
       minimalSetup
     ]
-    if (this.latexsSuitePlugin) {
+    if (!!this.latexsSuitePlugin) {
       // the language put eveything in a "math" node
       // surrounded by "math-begin" and "math-end" 
       // so that latex-suite always thinks we are in mathmode

--- a/src/utils/excalidrawAutomateUtils.ts
+++ b/src/utils/excalidrawAutomateUtils.ts
@@ -667,20 +667,8 @@ export function repositionElementsToCursor(
 export const insertLaTeXToView = (view: ExcalidrawView, center: boolean = false) => {
   const app = view.plugin.app;
   const ea = getEA(view) as ExcalidrawAutomate;
-  const isLatexSuitAvailable = !!app.plugins.plugins["obsidian-latex-suite"];
-  (isLatexSuitAvailable
-    ? LaTexPrompt.Prompt(app, t("ENTER_LATEX"), view.plugin.settings.latexBoilerplate)
-    : GenericInputPrompt.Prompt(
-        view,
-        view.plugin,
-        app,
-        t("ENTER_LATEX"),
-        "\\color{red}\\oint_S {E_n dA = \\frac{1}{{\\varepsilon _0 }}} Q_{inside}",
-        view.plugin.settings.latexBoilerplate,
-        undefined,
-        3
-      )
-  ).then(async (formula: string) => {
+  LaTexPrompt.Prompt(app, t("ENTER_LATEX"), view.plugin.settings.latexBoilerplate)
+  .then(async (formula: string) => {
     const lastLatexEl = ea.getViewElements()
         .filter((el) => el.type === "image" && view.excalidrawData.hasEquation(el.fileId))
         .reduce(

--- a/src/view/ExcalidrawView.ts
+++ b/src/view/ExcalidrawView.ts
@@ -1112,12 +1112,8 @@ export default class ExcalidrawView extends TextFileView implements HoverParent{
       if(!equation) return;
     }
 
-    const isLatexSuitAvailable = !!this.app.plugins.plugins["obsidian-latex-suite"];
-    (isLatexSuitAvailable
-      ? LaTexPrompt.Prompt(this.app, t("ENTER_LATEX"), equation)
-      : GenericInputPrompt.Prompt(
-        this,this.plugin,this.app,t("ENTER_LATEX"),undefined,equation, undefined, 3)
-    ).then(async (formula: string) => {
+    LaTexPrompt.Prompt(this.app, t("ENTER_LATEX"), equation)
+    .then(async (formula: string) => {
       if (!formula || formula === equation) {
         return;
       }


### PR DESCRIPTION
I put everything in `LatexPrompt` since it is easier (and there is already a fallback if latexsuite is not avaible inside)

Sadly I am forced to use `enableKeyCapture()` because otherwise the key event do not get to latex-suite.  
But this means that the modal steal focus when clicking outside.

We would prefer to allow the key-event to go through when it has focus but without stealing focus, is it possible? 

*(anyway this is a detail, keeping focus is fine I think)*