### PR TITLE
Fix the floating LaTeX-Modal

### DIFF
--- a/src/shared/Dialogs/FloatingModal.ts
+++ b/src/shared/Dialogs/FloatingModal.ts
@@ -1,4 +1,5 @@
 import { App, Modal } from "obsidian";
+import { clamp } from "@radix-ui/number";
 
 function getClientPoint(e: PointerEvent | TouchEvent) {
   if (e.type.startsWith("touch")) {
@@ -26,13 +27,13 @@ function isPointOnText(e: PointerEvent | TouchEvent, doc: Document): boolean {
   let offset: number | null = null;
 
   // Chromium/Firefox-ish
-  const caretPos = (doc as any).caretPositionFromPoint?.(pt.x, pt.y);
+  const caretPos = doc.caretPositionFromPoint?.(pt.x, pt.y);
   if (caretPos?.offsetNode) {
     offsetNode = caretPos.offsetNode;
     offset = typeof caretPos.offset === "number" ? caretPos.offset : null;
   } else {
     // Safari/WebKit
-    const caretRange = (doc as any).caretRangeFromPoint?.(pt.x, pt.y);
+    const caretRange = doc.caretRangeFromPoint?.(pt.x, pt.y);
     if (caretRange?.startContainer) {
       offsetNode = caretRange.startContainer;
       offset = typeof caretRange.startOffset === "number" ? caretRange.startOffset : null;
@@ -67,14 +68,13 @@ export class FloatingModal extends Modal {
   private dragging = false;
   private offsetX = 0;
   private offsetY = 0;
-  private pointerDownHandler: (e: PointerEvent | TouchEvent) => void;
-  private pointerMoveHandler: (e: PointerEvent | TouchEvent) => void;
-  private pointerUpHandler: () => void;
+  private readonly pointerDownHandler: (e: PointerEvent | TouchEvent) => void;
+  private readonly pointerMoveHandler: (e: PointerEvent | TouchEvent) => void;
+  private readonly pointerUpHandler: () => void;
 
   private disableKeyCapture = true; // new flag: when true, let keystrokes pass through to workspace
-  private previousActive: HTMLElement | null = null; // stores element focused before opening
-  private escListener: (e: KeyboardEvent) => void;
-  private modalKeydownStopHandler: (e: KeyboardEvent) => void; // store handler so we can remove it
+  private previousActive?: HTMLElement = null; // stores element focused before opening
+  private readonly modalKeydownStopHandler: (e: KeyboardEvent) => void; // store handler so we can remove it
   private ownerWindow: Window = window;
   private ownerDocument: Document = document;
 
@@ -84,8 +84,22 @@ export class FloatingModal extends Modal {
     this.pointerDownHandler = this.handlePointerDown.bind(this);
     this.pointerMoveHandler = this.handlePointerMove.bind(this);
     this.pointerUpHandler = this.handlePointerUp.bind(this);
-    this.escListener = this.handleEscKey.bind(this);
     this.modalKeydownStopHandler = (ev: KeyboardEvent) => ev.stopPropagation();
+
+    this.setDimBackground(false);
+  }
+
+  protected shouldNotStartDrag(target: HTMLElement, event: PointerEvent | TouchEvent): boolean {
+    return Boolean(
+      target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement ||
+      target instanceof HTMLSelectElement ||
+      target instanceof HTMLButtonElement ||
+      isPointOnText(event, this.ownerDocument) ||
+      target.closest(".clickable-icon") ||
+      // ensure close button never starts drag
+      target.closest(".modal-close-button")
+    )
   }
 
   private handlePointerDown(e: PointerEvent | TouchEvent): void {
@@ -93,15 +107,7 @@ export class FloatingModal extends Modal {
     const target = e.target as HTMLElement;
 
     // Ignore if clicking on interactive elements
-    if (
-      target instanceof HTMLInputElement ||
-      target instanceof HTMLTextAreaElement ||
-      target instanceof HTMLSelectElement ||
-      target instanceof HTMLButtonElement ||
-      isPointOnText(e, this.ownerDocument) ||
-      target.closest(".clickable-icon") ||
-      target.closest(".modal-close-button") // ensure close button never starts drag
-    ) {
+    if (this.shouldNotStartDrag(target, e)) {
       return;
     }
 
@@ -149,25 +155,18 @@ export class FloatingModal extends Modal {
     e.preventDefault();
     if (e.type === "touchmove") e.stopPropagation();
 
-    let clientX, clientY;
+    const { clientX, clientY } = (e.type === "touchmove") ?
+        (e as TouchEvent).touches[0] : e as PointerEvent;
 
-    if (e.type === "touchmove") {
-      const touch = (e as TouchEvent).touches[0];
-      clientX = touch.clientX;
-      clientY = touch.clientY;
-    } else {
-      const pointerEvent = e as PointerEvent;
-      clientX = pointerEvent.clientX;
-      clientY = pointerEvent.clientY;
-    }
-
-    const x = clientX - this.offsetX;
-    const y = clientY - this.offsetY;
+    // Prevent moving the modal offscreen
+    const { width, height } = modalEl.getBoundingClientRect();
+    const margin = 8;
+    const x = clamp(clientX - this.offsetX, [margin, this.ownerWindow.innerWidth - width - margin]);
+    const y = clamp(clientY - this.offsetY, [margin, this.ownerWindow.innerHeight - height - margin]);
 
     // Position the modal element
     modalEl.style.left = `${x}px`;
     modalEl.style.top = `${y}px`;
-    modalEl.style.transform = "none"; // Remove centering transform
   }
 
   private handlePointerUp(): void {
@@ -180,13 +179,6 @@ export class FloatingModal extends Modal {
     this.ownerDocument.removeEventListener("touchcancel", this.pointerUpHandler);
   }
 
-  private handleEscKey(e: KeyboardEvent) {
-    if (e.key === "Escape") {
-      e.stopPropagation();
-      this.close();
-    }
-  }
-
   open(): void {
     super.open();
     this.ownerDocument = this.modalEl.ownerDocument ?? document;
@@ -194,21 +186,13 @@ export class FloatingModal extends Modal {
     // NEW: capture previously focused element & release Obsidian modal key trapping
     if (this.disableKeyCapture) {
       this.previousActive = this.ownerDocument.activeElement as HTMLElement | null;
-      try {
-        // @ts-ignore pop modal's key scope so keys are not intercepted
-        this.app.keymap.popScope(this.scope);
-      } catch {}
-      try {
-        // @ts-ignore prevent automatic selection / focus restoration
-        this.shouldRestoreSelection = false;
-      } catch {}
+      // prevent automatic selection / focus restoration
+      this.shouldRestoreSelection = false;
     }
     setTimeout(() => {
-      //@ts-ignore
-      const { containerEl, modalEl, bgEl, headerEl } = this;
-      containerEl.style.pointerEvents = "none";
-      if (bgEl) bgEl.style.display = "none";
-      if (headerEl) headerEl.style.pointerEvents = "none";
+      // @ts-ignore
+      const { containerEl, modalEl, bgEl } = this;
+      containerEl.addClass("mod-excalidraw-draggable")
 
       // Set initial position and make modal draggable
       if (modalEl) {
@@ -224,9 +208,6 @@ export class FloatingModal extends Modal {
         modalEl.style.left = `${centerX}px`;
         modalEl.style.top = `${centerY}px`;
         modalEl.style.transform = "none";
-        const modalStyle = this.ownerWindow.getComputedStyle(modalEl);
-        modalEl.style.borderBottomLeftRadius = modalStyle.borderTopLeftRadius;
-        modalEl.style.borderBottomRightRadius = modalStyle.borderTopRightRadius;
 
         // Add event listeners for both pointer and touch events
         modalEl.addEventListener("pointerdown", this.pointerDownHandler as (e: PointerEvent) => void);
@@ -237,6 +218,12 @@ export class FloatingModal extends Modal {
         if (this.disableKeyCapture) {
           // Prevent the modal from stealing focus
           modalEl.setAttr("tabindex", "-1");
+
+          // In order to propagate keypresses, modal container and backdrop
+          // need to ignore (and thus propagate) any pointerEvents.
+          containerEl.style.pointerEvents = "none";
+          if (bgEl) bgEl.style.pointerEvents = "none";
+
           // Refocus previous element (if still in DOM)
           if (this.previousActive?.isConnected) {
             this.previousActive.focus({ preventScroll: true });
@@ -244,8 +231,6 @@ export class FloatingModal extends Modal {
           // Stop key events originating inside the modal from bubbling back
           modalEl.addEventListener("keydown", this.modalKeydownStopHandler, { capture: true });
         }
-        // Add ESC listener (capture to run before underlying workspace)
-        this.ownerDocument.addEventListener("keydown", this.escListener, { capture: true });
 
         // NEW: re-enable pointer events on the close button so it is tappable on mobile
         const closeBtn = containerEl.querySelector(".modal-close-button");
@@ -271,7 +256,6 @@ export class FloatingModal extends Modal {
     }
     // Remove any remaining document event listeners
     this.handlePointerUp();
-    this.ownerDocument.removeEventListener("keydown", this.escListener, { capture: true });
 
     super.close();
   }

--- a/src/shared/Dialogs/Prompt.ts
+++ b/src/shared/Dialogs/Prompt.ts
@@ -7,8 +7,7 @@ import {
   Instruction,
   TFile,
   Notice,
-  TextAreaComponent,
-  getIcon,
+  TextAreaComponent
 } from "obsidian";
 import ExcalidrawView from "../../view/ExcalidrawView";
 import ExcalidrawPlugin from "../../core/main";
@@ -93,7 +92,7 @@ export class LaTexPrompt extends FloatingModal {
   private resolvePromise: (input: string) => void;
   private rejectPromise: (reason?: any) => void;
   private editorView : EditorView;
-  private latexsSuitePlugin : any;
+  private readonly latexsSuitePlugin : any;
 
   protected constructor(
     app: App,
@@ -114,11 +113,15 @@ export class LaTexPrompt extends FloatingModal {
     this.editorView.focus();
   }
 
+  protected shouldNotStartDrag(target: HTMLElement, event: PointerEvent | TouchEvent): boolean {
+    return target.closest(".cm-editor") != null || super.shouldNotStartDrag(target, event);
+  }
+
   public static Prompt(app: App,
     prompt_text?: string,
     default_value?: string,
   ): Promise<string>{
-    const latexprompt = new LaTexPrompt(app, prompt_text, default_value);
+    const latexprompt = new this(app, prompt_text, default_value);
 
     return latexprompt.waitForClose;
   }
@@ -138,9 +141,11 @@ export class LaTexPrompt extends FloatingModal {
         key:"Mod-Enter", 
         run : () => {this.submitCallback(); return true;}
       }]),
+      // obsidian class to inherit styling
+      EditorView.editorAttributes.of({class: "multi-select-container"}),
       minimalSetup
     ]
-    if (!!this.latexsSuitePlugin) {
+    if (this.latexsSuitePlugin) {
       // the language put eveything in a "math" node
       // surrounded by "math-begin" and "math-end" 
       // so that latex-suite always thinks we are in mathmode

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -83,6 +83,17 @@ declare module "obsidian" {
   interface Menu {
     items: MenuItem[];
   }
+  interface Modal {
+    /**
+     * Whether to *dim* the background behind the modal. If {@link dimmed} is `true`, the
+     * opacity-value from [setBackgroundOpacity]{@link Modal#setBackgroundOpacity} or
+     * the default of `0.85` is used.
+     * @note The hidden backdrop will still catch focus.
+     */
+    setDimBackground(dimmed: boolean): Modal;
+    /** Sets the opacity of the Modal backdrop. */
+    setBackgroundOpacity(opacity: number): Modal;
+  }
   interface Keymap {
     getRootScope(): Scope;
   }

--- a/styles.css
+++ b/styles.css
@@ -1096,12 +1096,65 @@ textarea.excalidraw-wysiwyg, .excalidraw input {
 	height:fit-content
 }
 
-.excalidraw-LatexPrompt .cm-content {
-  caret-color: var(--caret-color);
+.excalidraw-LatexPrompt {
+  .cm-editor {
+    margin-top: var(--size-4-2);
+    justify-content: center;
+    align-items: center;
+
+    /* this is safe, if unsupported, will be ignored */
+    anchor-name: --latex-editor;
+
+    & > .cm-scroller, & > .cm-announcment {
+      align-self: start;
+      width: 100%
+    }
+
+    /* taken from Obsidian, doesn't apply automatically,
+       because the rule does not have :focus-within */
+    &.cm-focused {
+      border-color: var(--background-modifier-border-focus);
+      transition: box-shadow 0.15s ease-in-out, border 0.15s ease-in-out;
+      box-shadow: 0 0 0 var(--input-border-width-focus) var(--background-modifier-border-focus);
+    }
+
+    /* centering the popup */
+    & .cm-tooltip-cursor.cm-tooltip {
+      left: unset !important;
+
+      & .cm-tooltip-arrow {
+        left: 50% !important;
+        transform: translateX(-50%);
+      }
+    }
+
+    mjx-container[jax="CHTML"][display="true"] {
+      margin: 0;
+    }
+  }
+
+  .cm-content {
+    caret-color: var(--caret-color);
+  }
 }
 
-.excalidraw-LatexPrompt .cm-editor {
-  margin-top: 90px;
+@supports (anchor-name: --test) {
+  .excalidraw-LatexPrompt .cm-editor .cm-tooltip-cursor.cm-tooltip {
+    position: fixed !important;
+    position-anchor: --latex-editor;
+    top: unset !important;
+    max-width: calc(100vw - var(--size-4-4));
+    margin: var(--size-4-2) 0;
+    overflow-x: clip;
+
+    &.cm-tooltip-above {
+      bottom: anchor(top);
+    }
+
+    &.cm-tooltip-below {
+      top: anchor(bottom) !important;
+    }
+  }
 }
 
 .excalidraw-filetype-tag {


### PR DESCRIPTION
* `FloatingModal` now respects `enableKeyCapture()` or rather `disableKeyCapture`, so that if `false`, the modal closes upon clicks outside its bounds (instead of propagating that event). (Instead of hiding the modal background using styles, we use the builtin methods from Obsidian to disable the `dim`)
* removed unnecessary poping of the superclasses keybind-scope, that only has _ESC to close_ which we previously implemented by hand.
* the FloatingModal can no longer be dragged outside the windows bounds.
* added method `FloatingModal#shouldNotStartDrag` to allow custom blocking of the drag-motion.
* cleaned up the code of `FloatingModal` by removing unnecessary assignments, try-catch blocks etc.
* styled the input of the LaTeX Modal like any other Obsidian Modal.
* disabled dragging for the `EditorView`, making it easier to select text and use the inputs drag-and-drop functionality
* centered the Latex Suite popup around the input and added anchor-positioning (with fallback), to allow a popup wider than the Modal (which previously would have clipped).