### PR TITLE
Auto-select node when opening Mindmap Builder

### DIFF
--- a/ea-scripts/Mindmap Builder.js
+++ b/ea-scripts/Mindmap Builder.js
@@ -1810,7 +1810,26 @@ const getMindmapNodeFromSelection = () => {
 }
 
 const ensureNodeSelected = () => {
-  const elementToSelect = getMindmapNodeFromSelection();
+  let elementToSelect = getMindmapNodeFromSelection();
+  
+  // Fallback: if nothing selected, try most recently selected or a root node
+  if (!elementToSelect) {
+    if (!mostRecentlySelectedNodeID) {
+      const roots = getMasterRoots();
+      if (roots.length > 0) {
+        mostRecentlySelectedNodeID = roots[0];
+      }
+    }
+    if (mostRecentlySelectedNodeID) {
+      const fallback = ea.getViewElements().find(el => el.id === mostRecentlySelectedNodeID);
+      if (fallback) {
+        elementToSelect = fallback;
+      } else {
+        mostRecentlySelectedNodeID = null;
+      }
+    }
+  }
+  
   if (elementToSelect) {
     selectNodeInView(elementToSelect);
   }


### PR DESCRIPTION
When opening the Mindmap Builder with no node selected, automatically select the most recently used node or the first root node found.