### PR TITLE
fix #2718

### DIFF
--- a/src/core/main.ts
+++ b/src/core/main.ts
@@ -1260,13 +1260,9 @@ export default class ExcalidrawPlugin extends Plugin {
     terminateCompressionWorker();
   }
 
-  public async loadSettings(opts: {
-    applyLefthandedMode?: boolean,
-    reEnableAutosave?: boolean
-  } = {applyLefthandedMode: true, reEnableAutosave: false}
+  public async loadSettings(opts: { reEnableAutosave?: boolean } = { reEnableAutosave: false }
   ) {
     (process.env.NODE_ENV === 'development') && DEBUGGING && debug(this.loadSettings,`ExcalidrawPlugin.loadSettings`, opts);
-    if(typeof opts.applyLefthandedMode === "undefined") opts.applyLefthandedMode = true;
     if(typeof opts.reEnableAutosave === "undefined") opts.reEnableAutosave = false;
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
     if(!this.settings.previewImageType) { //migration 1.9.13
@@ -1278,7 +1274,6 @@ export default class ExcalidrawPlugin extends Plugin {
           : PreviewImageType.PNG; 
       }
     }
-    if(opts.applyLefthandedMode) setLeftHandedMode(this.settings.isLeftHanded);
     if(opts.reEnableAutosave) this.settings.autosave = true;
     setDebugging(this.settings.isDebugMode);
   }

--- a/src/core/managers/CommandManager.ts
+++ b/src/core/managers/CommandManager.ts
@@ -1010,13 +1010,10 @@ export class CommandManager {
         const view = this.app.workspace.getActiveViewOfType(ExcalidrawView);
         (async()=>{
           const isLeftHanded = this.settings.isLeftHanded;
-          await this.plugin.loadSettings({applyLefthandedMode: false});
+          await this.plugin.loadSettings();
           this.settings.isLeftHanded = !isLeftHanded;
           this.plugin.saveSettings();
-          //not clear why I need to do this. If I don't double apply the stylesheet changes 
-          //then the style won't be applied in the popout windows
           setLeftHandedMode(!isLeftHanded);
-          setTimeout(()=>setLeftHandedMode(!isLeftHanded));
         })()
         return true;
       },

--- a/src/shared/Dialogs/UIModeSettingComponent.ts
+++ b/src/shared/Dialogs/UIModeSettingComponent.ts
@@ -96,10 +96,7 @@ export class UIModeSettingsComponent {
           .setValue(this.settings.isLeftHanded)
           .onChange(async (value) => {
             this.settings.isLeftHanded = value;
-            //not clear why I need to do this. If I don't double apply the stylesheet changes 
-            //then the style won't be applied in the popout windows
-            setLeftHandedMode(value); 
-            setTimeout(()=>setLeftHandedMode(value));
+            setLeftHandedMode(value);
             this.onChange();
           }),
       );

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -19,6 +19,7 @@ import {
   DEVICE,
   getContainerElement,
   SCRIPT_INSTALL_FOLDER,
+  VIEW_TYPE_EXCALIDRAW,
 } from "../constants/constants";
 import ExcalidrawPlugin from "../core/main";
 import { ExcalidrawElement, ExcalidrawImageElement, ExcalidrawTextElement, ImageCrop } from "@zsviczian/excalidraw/types/element/src/types";
@@ -42,6 +43,7 @@ import { ExcalidrawSettings } from "src/core/settings";
 import { FileData } from "src/types/embeddedFileLoaderTypes";
 import { ExportSettings } from "src/types/exportUtilTypes";
 import { UIMode } from "src/shared/Dialogs/UIModeSettingComponent";
+import ExcalidrawView from "../view/ExcalidrawView";
 
 declare const PLUGIN_VERSION:string;
 declare var LZString: any;
@@ -595,35 +597,14 @@ export function scaleLoadedImage (
   return { dirty, scene };
 };
 
-export function setDocLeftHandedMode(isLeftHanded: boolean, ownerDocument:Document) {
-  const newStylesheet = ownerDocument.createElement("style");
-  newStylesheet.id = "excalidraw-left-handed";
-  newStylesheet.textContent = `.excalidraw .App-bottom-bar {
-    justify-content:flex-end !important;
-    left: auto !important;
-    right: 0 !important;
-    transform: none !important;
-  }`;
-  const oldStylesheet = ownerDocument.getElementById(newStylesheet.id);
-  if (oldStylesheet) {
-    ownerDocument.head.removeChild(oldStylesheet);
-  }
-  if (isLeftHanded) {
-    ownerDocument.head.appendChild(newStylesheet);
-  }
-}
-
 export function setLeftHandedMode (isLeftHanded: boolean) {
-  if(DEVICE.isPhone) return; //no lefthanded mode on phones
-  const visitedDocs = new Set<Document>();
-  EXCALIDRAW_PLUGIN.app.workspace.iterateAllLeaves((leaf) => {
-    const ownerDocument = DEVICE.isMobile?document:leaf.view.containerEl.ownerDocument;
-    if(!ownerDocument) return;
-    if(visitedDocs.has(ownerDocument)) return;
-    visitedDocs.add(ownerDocument);
-    setDocLeftHandedMode(isLeftHanded,ownerDocument);
+  if (DEVICE.isPhone) return; // no left-handed mode on phones
+  EXCALIDRAW_PLUGIN.app.workspace.getLeavesOfType(VIEW_TYPE_EXCALIDRAW).forEach((leaf) => {
+    if (leaf.view instanceof ExcalidrawView) {
+      leaf.view.setHandedness(isLeftHanded);
+    }
   })  
-};
+}
 
 export function calculateUIModeValue(settings: ExcalidrawSettings): UIMode {
   const phoneMode = settings.phoneUIMode ?? "mobile";

--- a/src/view/ExcalidrawView.ts
+++ b/src/view/ExcalidrawView.ts
@@ -6263,8 +6263,11 @@ export default class ExcalidrawView extends TextFileView implements HoverParent{
     //console.log("ExcalidrawView.instantiateExcalidraw()");
     this.clearDirty();
 
+    // apply the handedness, settings were just reloaded in the calling method.
+    this.setHandedness(this.plugin.settings.isLeftHanded);
+
     this.excalidrawRoot = ReactDOM.createRoot(this.contentEl);
-    this.excalidrawRoot.render(React.createElement(this.excalidrawRootElement.bind(this,initdata)));
+    this.excalidrawRoot.render(React.createElement(this.excalidrawRootElement.bind(this, initdata)));
   }
 
   private updateContainerSize(containerId?: string, delay: boolean = false, justloaded: boolean = false) {
@@ -6394,6 +6397,14 @@ export default class ExcalidrawView extends TextFileView implements HoverParent{
     (process.env.NODE_ENV === 'development') && DEBUGGING && debug(this.setUIMode, "ExcalidrawView.setDesktopUIMode");
     const api = this.excalidrawAPI as ExcalidrawImperativeAPI;
     api.setDesktopUIMode(mode);
+  }
+
+  /**
+   * Applies the desired handedness to this `ExcalidrawView`.
+   * @param isLeftHanded - the desired handedness
+   */
+  public setHandedness(isLeftHanded: boolean) {
+    this.contentEl.toggleClass("excalidraw-left-handed", isLeftHanded);
   }
 
   /**

--- a/styles.css
+++ b/styles.css
@@ -1046,6 +1046,21 @@ textarea.excalidraw-wysiwyg, .excalidraw input {
   z-index: 9999;
 }
 
+.excalidraw .App-bottom-bar .App-toolbar {
+  justify-content: start;
+}
+
+.excalidraw-left-handed .excalidraw .App-bottom-bar {
+  justify-content: flex-end !important;
+  left: auto !important;
+  right: 0 !important;
+  transform: none !important;
+
+  .App-toolbar {
+    justify-content: end;
+  }
+}
+
 .excalidraw--tray .App-bottom-bar > .Island > .App-toolbar > .App-toolbar-content {
   /* This will render the undo/redo buttons as if they weren't
   in a separate container, but simply part of the row */


### PR DESCRIPTION
fixes #2718. I rewrote the toggle-mechanism for the left-handedness to use css-classes, making it easier to style. 
I also tested in popout windows, where I removed some logic that previously set the style twice.

The actual fix is in `styles.css`; when I first made that change, I already had that in my stylesheet.