### PR TITLE
fix: prevent JSON corruption in exportSceneToMD when replacing text element IDs

### DIFF
--- a/src/core/managers/FileManager.ts
+++ b/src/core/managers/FileManager.ts
@@ -378,14 +378,14 @@ export class PluginFileManager {
       //also Excalidraw IDs are inconveniently long
       if (te.id.length > 8) {
         id = nanoid();
-        data = data.replaceAll(te.id, id); //brute force approach to replace all occurrences.
+        te.id = id; // Update the element's own ID in the parsed object
       }
       outString += `${te.originalText ?? te.text} ^${id}\n\n`;
     }
     return (
       outString +
       getMarkdownDrawingSection(
-        JSON.stringify(JSON_parse(data), null, "\t"),
+        JSON.stringify(excalidrawData, null, "\t"),
         typeof compressOverride === "undefined"
         ? this.settings.compress
         : compressOverride,


### PR DESCRIPTION
## Fix for #2724

### Bug
In `exportSceneToMD()` (FileManager.ts), the code was using string replacement to swap text element IDs:

```typescript
// BEFORE (buggy)
data = data.replaceAll(te.id, id); // brute force - replaces ALL occurrences in raw JSON
```

This replaced ALL occurrences of `te.id` in the raw JSON string, including in `boundElements`, `groupIds`, `frameId`, and other fields that reference the same element ID. This corrupted the JSON structure, causing the converted .excalidraw.md file to fail loading with "Excalidraw JSON not found" errors.

### Fix
Instead of modifying the raw JSON string, directly update `te.id` on the parsed object, then serialize the modified object:

```typescript
// AFTER (fixed)
te.id = id; // Update the element's own ID in the parsed object
// ...
JSON.stringify(excalidrawData) // Use the correctly modified parsed object
```

This ensures only the element's own ID field is updated, without accidentally corrupting other references in the JSON.

---

Closes #2724