### PR TITLE
Keep interactive Markdown ink above previews

### DIFF
--- a/src/shared/EmbeddedFileLoader.ts
+++ b/src/shared/EmbeddedFileLoader.ts
@@ -3,6 +3,8 @@
 
 import {
   ExcalidrawElement,
+  ExcalidrawEmbeddableElement,
+  ExcalidrawImageElement,
   FileId,
 } from "@zsviczian/excalidraw/types/element/src/types";
 import { DataURL } from "@zsviczian/excalidraw/types/excalidraw/types";
@@ -89,6 +91,7 @@ type CacheValidationMode = "validated" | "stale-first";
 type LoadImageOptions = {
   cacheValidation?: CacheValidationMode;
   onStaleCacheHit?: () => void;
+  markdownRenderSize?: Size;
 };
 
 type LoadSceneEmitPolicy = "all" | "changed-only";
@@ -439,6 +442,7 @@ export class EmbeddedFilesLoader {
   public async getObsidianImage(
     inFile: TFile | EmbeddedFile,
     depth: number,
+    options?: LoadImageOptions,
   ): Promise<{
     mimeType: MimeType;
     fileId: FileId;
@@ -449,10 +453,50 @@ export class EmbeddedFilesLoader {
     pdfPageViewProps?: PDFPageViewProps;
   }> {
     try {
-      return await this._getObsidianImage(inFile, depth);
+      return await this._getObsidianImage(inFile, depth, options);
     } finally {
       this.emptyPDFDocsMap();
     }
+  }
+
+  private getInteractiveMarkdownPreviewRenderSize(
+    elements: readonly ExcalidrawElement[],
+    fileId: FileId,
+  ): Size | undefined {
+    const preview = elements.find(
+      (el): el is ExcalidrawImageElement =>
+        el.type === "image" &&
+        el.fileId === fileId &&
+        Boolean(el.customData?.interactiveMarkdownEmbeddablePreview),
+    );
+    if (!preview) {
+      return;
+    }
+
+    const embeddableId =
+      typeof preview.customData?.interactiveMarkdownEmbeddableId === "string"
+        ? preview.customData.interactiveMarkdownEmbeddableId
+        : null;
+    const embeddable = embeddableId
+      ? elements.find(
+          (el): el is ExcalidrawEmbeddableElement =>
+            el.type === "embeddable" && el.id === embeddableId,
+        )
+      : null;
+    const source = embeddable ?? preview;
+    const scaleX = Math.abs(source.scale?.[0] ?? 1) || 1;
+    const scaleY = Math.abs(source.scale?.[1] ?? 1) || 1;
+    const width =
+      Number(preview.customData?.interactiveMarkdownPreviewSyncedWidth) ||
+      source.width / scaleX;
+    const height =
+      Number(preview.customData?.interactiveMarkdownPreviewSyncedHeight) ||
+      source.height / scaleY;
+
+    return {
+      width: Math.max(1, Math.round(width)),
+      height: Math.max(1, Math.round(height)),
+    };
   }
 
   private async getExcalidrawSVG({
@@ -690,8 +734,12 @@ export class EmbeddedFilesLoader {
               path: file.path,
               isBlockRef: false,
               ref: null,
-              width: this.plugin.settings.mdSVGwidth,
-              height: this.plugin.settings.mdSVGmaxHeight,
+              width:
+                options?.markdownRenderSize?.width ??
+                this.plugin.settings.mdSVGwidth,
+              height:
+                options?.markdownRenderSize?.height ??
+                this.plugin.settings.mdSVGmaxHeight,
               page: null,
             };
 
@@ -786,7 +834,13 @@ export class EmbeddedFilesLoader {
           const result = await this.convertMarkdownToSVG(
             this.plugin,
             file,
-            linkParts,
+            options?.markdownRenderSize
+              ? {
+                  ...linkParts,
+                  width: options.markdownRenderSize.width,
+                  height: options.markdownRenderSize.height,
+                }
+              : linkParts,
           );
           dataURL = result.dataURL;
           hasSVGwithBitmap = result.hasSVGwithBitmap;
@@ -902,11 +956,24 @@ export class EmbeddedFilesLoader {
             if (this.terminate) {
               return;
             }
-            const shouldForceReload = forceReloadFileIDs?.has(id);
+            const markdownRenderSize =
+              this.getInteractiveMarkdownPreviewRenderSize(
+                excalidrawData.scene.elements,
+                id,
+              );
+            const markdownRenderSizeChanged =
+              markdownRenderSize &&
+              (Math.round(embeddedFile.size.width) !==
+                markdownRenderSize.width ||
+                Math.round(embeddedFile.size.height) !==
+                  markdownRenderSize.height);
+            const shouldForceReload =
+              forceReloadFileIDs?.has(id) || markdownRenderSizeChanged;
             if (shouldForceReload || !embeddedFile.isLoaded(this.isDark)) {
               //debug({where:"EmbeddedFileLoader.loadSceneFiles",uid:this.uid,status:"embedded Files are not loaded"});
               const data = await this._getObsidianImage(embeddedFile, depth, {
                 cacheValidation,
+                markdownRenderSize,
                 onStaleCacheHit:
                   cacheValidation === "stale-first"
                     ? () => deferredValidationFileIds.add(id)

--- a/src/utils/elementCustomDataUtils.ts
+++ b/src/utils/elementCustomDataUtils.ts
@@ -29,6 +29,16 @@ export type ExcalidrawLatexCustomData = ExcalidrawCustomData & {
   latexscale?: number;
 };
 
+export type ExcalidrawInteractiveMarkdownPreviewCustomData =
+  ExcalidrawCustomData & {
+    interactiveMarkdownEmbeddableId?: string;
+    interactiveMarkdownEmbeddablePreview?: boolean;
+    interactiveMarkdownPreviewBacked?: boolean;
+    interactiveMarkdownPreviewId?: string;
+    interactiveMarkdownPreviewSyncedWidth?: number;
+    interactiveMarkdownPreviewSyncedHeight?: number;
+  };
+
 export type ExcalidrawImageWithCustomData<
   TCustomData extends ExcalidrawCustomData = ExcalidrawCustomData,
 > = ExcalidrawImageElement & {

--- a/src/utils/excalidrawViewUtils.ts
+++ b/src/utils/excalidrawViewUtils.ts
@@ -48,6 +48,7 @@ import { CaptureUpdateAction } from "src/constants/constants";
 import { setSanitizedHtml } from "./htmlUtils";
 import { URLs } from "src/constants/safeUrls";
 import { isInstanceOfHTMLDivElement } from "./typechecks";
+import { addAppendUpdateCustomData } from "./elementCustomDataUtils";
 
 type CommandLinkOptInPlugin = {
   settings: {
@@ -254,6 +255,58 @@ export function deleteAppStateKeys(
   return st;
 }
 
+type MarkdownInteractiveEmbedPreviewSpec = {
+  imageSource: TFile | string;
+};
+
+function getMarkdownInteractiveEmbedPreviewSpec(
+  ea: ExcalidrawAutomate,
+  file?: TFile,
+  link?: string,
+): MarkdownInteractiveEmbedPreviewSpec | null {
+  if (file?.extension?.toLowerCase() === "md") {
+    return {
+      imageSource: file,
+    };
+  }
+
+  if (!link || link.match(REG_LINKINDEX_HYPERLINK)) {
+    return null;
+  }
+
+  const parts = REGEX_LINK.getRes(link).next();
+  const linkText = parts.value
+    ? REGEX_LINK.getLink(parts)
+    : getLinkFromMarkdownLink(link);
+  if (!linkText || linkText.match(REG_LINKINDEX_HYPERLINK)) {
+    return null;
+  }
+
+  const sourceFile = ea.targetView?.file;
+  const linkParts = getLinkParts(linkText, sourceFile);
+  if (!linkParts.path) {
+    return null;
+  }
+
+  const resolvedFile = ea.plugin.app.metadataCache.getFirstLinkpathDest(
+    linkParts.path,
+    sourceFile?.path ?? "",
+  );
+  if (resolvedFile?.extension?.toLowerCase() !== "md") {
+    return null;
+  }
+
+  const imageSource = linkParts.ref
+    ? `${resolvedFile.path}#${linkParts.isBlockRef ? "^" : ""}${
+        linkParts.ref
+      }`
+    : resolvedFile;
+
+  return {
+    imageSource,
+  };
+}
+
 export async function insertEmbeddableToView(
   ea: ExcalidrawAutomate,
   position: { x: number; y: number },
@@ -300,7 +353,47 @@ export async function insertEmbeddableToView(
       shouldInsertToView,
     );
   }
+  let width = MAX_IMAGE_SIZE;
   let height = MAX_IMAGE_SIZE;
+  let previewImageId: string | null = null;
+  const markdownPreviewSpec = getMarkdownInteractiveEmbedPreviewSpec(
+    ea,
+    file,
+    link,
+  );
+  if (markdownPreviewSpec) {
+    const currentStyle = {
+      backgroundColor: ea.style.backgroundColor,
+      strokeColor: ea.style.strokeColor,
+    };
+    ea.setStyle({
+      backgroundColor: "transparent",
+      strokeColor: "transparent",
+    });
+    try {
+      previewImageId = await ea.addImage(
+        position.x,
+        position.y,
+        markdownPreviewSpec.imageSource,
+      );
+    } finally {
+      ea.setStyle(currentStyle);
+    }
+    if (previewImageId) {
+      const previewImage = ea.getElement(
+        previewImageId,
+      ) as Mutable<ExcalidrawImageElement>;
+      if (previewImage) {
+        previewImage.x = position.x;
+        previewImage.y = position.y;
+        width = previewImage.width;
+        height = previewImage.height;
+        addAppendUpdateCustomData(previewImage, {
+          interactiveMarkdownEmbeddablePreview: true,
+        });
+      }
+    }
+  }
   if (
     (file && AUDIO_TYPES.contains(file.extension.toLowerCase())) ||
     (link &&
@@ -314,14 +407,41 @@ export async function insertEmbeddableToView(
     });
     height = getAudioElementHeight();
   }
+  if (previewImageId) {
+    ea.setStyle({
+      backgroundColor: "transparent",
+    });
+  }
   const id = ea.addEmbeddable(
     position.x,
     position.y,
-    MAX_IMAGE_SIZE,
+    width,
     height,
     link,
     file,
   );
+  if (previewImageId) {
+    const groupId = nanoid();
+    const embeddable = ea.getElement(id) as Mutable<ExcalidrawElement>;
+    const previewImage = ea.getElement(
+      previewImageId,
+    ) as Mutable<ExcalidrawImageElement>;
+    if (embeddable && previewImage) {
+      previewImage.x = embeddable.x = position.x;
+      previewImage.y = embeddable.y = position.y;
+      previewImage.width = embeddable.width;
+      previewImage.height = embeddable.height;
+      embeddable.groupIds = [...embeddable.groupIds, groupId];
+      previewImage.groupIds = [...previewImage.groupIds, groupId];
+      addAppendUpdateCustomData(embeddable, {
+        interactiveMarkdownPreviewBacked: true,
+        interactiveMarkdownPreviewId: previewImageId,
+      });
+      addAppendUpdateCustomData(previewImage, {
+        interactiveMarkdownEmbeddableId: id,
+      });
+    }
+  }
   if (shouldInsertToView) {
     await ea.addElementsToView(false, true, true);
   }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -569,7 +569,10 @@ export function scaleLoadedImage<T extends SceneWithElements>(
 
     sceneElements
       .filter(
-        (e: ExcalidrawElement) => e.type === "image" && e.fileId === img.id,
+        (e: ExcalidrawElement) =>
+          e.type === "image" &&
+          e.fileId === img.id &&
+          !e.customData?.interactiveMarkdownEmbeddablePreview,
       )
       .forEach((el: Mutable<ExcalidrawImageElement>) => {
         const [elWidth, elHeight] = [el.width, el.height];

--- a/src/view/ExcalidrawView.ts
+++ b/src/view/ExcalidrawView.ts
@@ -287,6 +287,15 @@ interface WorkspaceItemExt extends WorkspaceItem {
 const HIDE = "excalidraw-hidden";
 const SHOW = "excalidraw-visible";
 
+type InteractiveMarkdownPreviewPair = {
+  embeddable: Mutable<ExcalidrawEmbeddableElement>;
+  preview: Mutable<ExcalidrawImageElement>;
+  renderWidth: number;
+  renderHeight: number;
+  needsImageReload: boolean;
+  needsGeometrySync: boolean;
+};
+
 export const addFiles = async (
   files: FileData[],
   view: ExcalidrawView,
@@ -468,6 +477,10 @@ export default class ExcalidrawView
   private resizeBatchWindowStart: number = 0;
   private lastAggregatedDh = 0;
   private oldKeyboardScroll: { scrollY: number; scrollX: number } | null = null;
+  private interactiveMarkdownPreviewSyncTimer: number | null = null;
+  private interactiveMarkdownPreviewSyncPromise: Promise<void> | null = null;
+  private interactiveMarkdownPreviewSyncInProgress = false;
+  private interactiveMarkdownPreviewSyncQueued = false;
 
   //https://stackoverflow.com/questions/27132796/is-there-any-javascript-event-fired-when-the-on-screen-keyboard-on-mobile-safari
   private isEditingTextResetTimer: number | null = null;
@@ -1132,8 +1145,10 @@ export default class ExcalidrawView
       return;
     }
 
-    const allowSave = this.isDirty() || forcesave; //removed this.semaphores.autosaving
     try {
+      await this.flushInteractiveMarkdownPreviewSync();
+
+      const allowSave = this.isDirty() || forcesave; //removed this.semaphores.autosaving
       if (allowSave) {
         const scene = this.getScene();
 
@@ -2908,6 +2923,11 @@ export default class ExcalidrawView
       window.clearTimeout(this.colorChangeTimer);
       this.colorChangeTimer = null;
     }
+    if (this.interactiveMarkdownPreviewSyncTimer) {
+      window.clearTimeout(this.interactiveMarkdownPreviewSyncTimer);
+      this.interactiveMarkdownPreviewSyncTimer = null;
+    }
+    this.interactiveMarkdownPreviewSyncQueued = false;
     if (this.semaphores?.wheelTimeout) {
       window.clearTimeout(this.semaphores.wheelTimeout);
       this.semaphores.wheelTimeout = null;
@@ -5560,11 +5580,240 @@ export default class ExcalidrawView
     }
   }
 
+  private getInteractiveMarkdownPreviewPairs(
+    elements: readonly ExcalidrawElement[],
+  ): InteractiveMarkdownPreviewPair[] {
+    const byId = new Map(elements.map((el) => [el.id, el]));
+    const pairs: InteractiveMarkdownPreviewPair[] = [];
+    const threshold = 0.5;
+
+    for (const element of elements) {
+      if (
+        element.type !== "embeddable" ||
+        !element.customData?.interactiveMarkdownPreviewBacked
+      ) {
+        continue;
+      }
+
+      const previewId =
+        typeof element.customData.interactiveMarkdownPreviewId === "string"
+          ? element.customData.interactiveMarkdownPreviewId
+          : null;
+      const preview = previewId ? byId.get(previewId) : null;
+      if (
+        !preview ||
+        preview.type !== "image" ||
+        !preview.customData?.interactiveMarkdownEmbeddablePreview
+      ) {
+        continue;
+      }
+
+      const embeddable = element as Mutable<ExcalidrawEmbeddableElement>;
+      const previewImage = preview as Mutable<ExcalidrawImageElement>;
+      const scaleX = Math.abs(embeddable.scale?.[0] ?? 1) || 1;
+      const scaleY = Math.abs(embeddable.scale?.[1] ?? 1) || 1;
+      const renderWidth = Math.max(1, Math.round(embeddable.width / scaleX));
+      const renderHeight = Math.max(1, Math.round(embeddable.height / scaleY));
+      const syncedWidth = Number(
+        previewImage.customData?.interactiveMarkdownPreviewSyncedWidth,
+      );
+      const syncedHeight = Number(
+        previewImage.customData?.interactiveMarkdownPreviewSyncedHeight,
+      );
+      const previewScaleX = Math.abs(previewImage.scale?.[0] ?? 1);
+      const previewScaleY = Math.abs(previewImage.scale?.[1] ?? 1);
+
+      pairs.push({
+        embeddable,
+        preview: previewImage,
+        renderWidth,
+        renderHeight,
+        needsImageReload:
+          syncedWidth !== renderWidth || syncedHeight !== renderHeight,
+        needsGeometrySync:
+          Math.abs(previewImage.x - embeddable.x) > threshold ||
+          Math.abs(previewImage.y - embeddable.y) > threshold ||
+          Math.abs(previewImage.width - embeddable.width) > threshold ||
+          Math.abs(previewImage.height - embeddable.height) > threshold ||
+          Math.abs(previewImage.angle - embeddable.angle) > 0.001 ||
+          Math.abs(previewScaleX - 1) > 0.001 ||
+          Math.abs(previewScaleY - 1) > 0.001,
+      });
+    }
+
+    return pairs;
+  }
+
+  private scheduleInteractiveMarkdownPreviewSync(delay = 250) {
+    if (
+      !this.excalidrawAPI ||
+      !this.excalidrawData ||
+      this.semaphores?.viewunload
+    ) {
+      return;
+    }
+
+    this.interactiveMarkdownPreviewSyncQueued = true;
+
+    if (this.interactiveMarkdownPreviewSyncInProgress) {
+      return;
+    }
+
+    if (this.interactiveMarkdownPreviewSyncTimer) {
+      window.clearTimeout(this.interactiveMarkdownPreviewSyncTimer);
+    }
+
+    this.interactiveMarkdownPreviewSyncTimer = window.setTimeout(() => {
+      this.interactiveMarkdownPreviewSyncTimer = null;
+      void this.syncInteractiveMarkdownPreviewBackings();
+    }, delay);
+  }
+
+  private async flushInteractiveMarkdownPreviewSync() {
+    if (this.interactiveMarkdownPreviewSyncTimer) {
+      window.clearTimeout(this.interactiveMarkdownPreviewSyncTimer);
+      this.interactiveMarkdownPreviewSyncTimer = null;
+    }
+
+    if (this.interactiveMarkdownPreviewSyncInProgress) {
+      this.interactiveMarkdownPreviewSyncQueued = true;
+      await this.interactiveMarkdownPreviewSyncPromise;
+      return;
+    }
+
+    await this.syncInteractiveMarkdownPreviewBackings();
+  }
+
+  private async syncInteractiveMarkdownPreviewBackings() {
+    if (
+      !this.excalidrawAPI ||
+      !this.excalidrawData ||
+      this.semaphores?.viewunload
+    ) {
+      return;
+    }
+
+    if (this.interactiveMarkdownPreviewSyncInProgress) {
+      this.interactiveMarkdownPreviewSyncQueued = true;
+      await this.interactiveMarkdownPreviewSyncPromise;
+      return;
+    }
+
+    this.interactiveMarkdownPreviewSyncPromise = (async () => {
+      this.interactiveMarkdownPreviewSyncInProgress = true;
+      try {
+        do {
+          this.interactiveMarkdownPreviewSyncQueued = false;
+          await this.syncInteractiveMarkdownPreviewBackingsOnce();
+        } while (
+          this.interactiveMarkdownPreviewSyncQueued &&
+          !this.semaphores?.viewunload
+        );
+      } finally {
+        this.interactiveMarkdownPreviewSyncInProgress = false;
+        this.interactiveMarkdownPreviewSyncPromise = null;
+      }
+    })();
+
+    await this.interactiveMarkdownPreviewSyncPromise;
+  }
+
+  private async syncInteractiveMarkdownPreviewBackingsOnce() {
+    if (!this.excalidrawAPI || !this.excalidrawData) {
+      return;
+    }
+
+    const elements =
+      this.excalidrawAPI.getSceneElementsIncludingDeleted() as Mutable<
+        ExcalidrawElement
+      >[];
+    const pairs = this.getInteractiveMarkdownPreviewPairs(elements);
+    const pairsToUpdate = pairs.filter(
+      (pair) => pair.needsGeometrySync || pair.needsImageReload,
+    );
+    if (pairsToUpdate.length === 0) {
+      return;
+    }
+
+    let geometryDirty = false;
+    for (const pair of pairsToUpdate) {
+      const { embeddable, preview, renderWidth, renderHeight } = pair;
+      if (pair.needsGeometrySync) {
+        preview.x = embeddable.x;
+        preview.y = embeddable.y;
+        preview.width = embeddable.width;
+        preview.height = embeddable.height;
+        preview.angle = embeddable.angle;
+        preview.scale = [1, 1];
+        geometryDirty = true;
+      }
+      addAppendUpdateCustomData(preview, {
+        interactiveMarkdownEmbeddableId: embeddable.id,
+        interactiveMarkdownPreviewSyncedWidth: renderWidth,
+        interactiveMarkdownPreviewSyncedHeight: renderHeight,
+      });
+      addAppendUpdateCustomData(embeddable, {
+        interactiveMarkdownPreviewId: preview.id,
+      });
+      geometryDirty = true;
+    }
+
+    if (geometryDirty) {
+      this.updateScene({
+        elements,
+        captureUpdate: CaptureUpdateAction.NEVER,
+      });
+    }
+
+    const filesToUpdate: FileData[] = [];
+    const isDark = this.excalidrawAPI.getAppState()?.theme === "dark";
+    for (const pair of pairsToUpdate.filter((item) => item.needsImageReload)) {
+      const embeddedFile = this.excalidrawData.getFile(pair.preview.fileId);
+      if (!embeddedFile) {
+        continue;
+      }
+      const loader = new EmbeddedFilesLoader(this.plugin, isDark);
+      const data = await loader.getObsidianImage(embeddedFile, 0, {
+        markdownRenderSize: {
+          width: pair.renderWidth,
+          height: pair.renderHeight,
+        },
+      });
+      if (!data?.dataURL) {
+        continue;
+      }
+      embeddedFile.setImage({
+        imgBase64: data.dataURL,
+        mimeType: data.mimeType,
+        size: data.size,
+        isDark,
+        isSVGwithBitmap: data.hasSVGwithBitmap,
+        pdfPageViewProps: data.pdfPageViewProps,
+      });
+      filesToUpdate.push({
+        mimeType: data.mimeType,
+        id: pair.preview.fileId,
+        dataURL: data.dataURL,
+        created: data.created,
+        size: data.size,
+        hasSVGwithBitmap: data.hasSVGwithBitmap,
+        shouldScale: false,
+        pdfPageViewProps: data.pdfPageViewProps,
+      });
+    }
+
+    if (filesToUpdate.length > 0) {
+      this.excalidrawAPI.addFiles(filesToUpdate);
+    }
+    this.setDirty();
+  }
+
   private onChange(
     et: ExcalidrawElement[],
     st: AppState,
     files: BinaryFileData[],
   ) {
+    this.scheduleInteractiveMarkdownPreviewSync();
     if (st.activeTool?.type) {
       if (st.activeTool.type === "image") {
         if (

--- a/src/view/components/CustomEmbeddable.tsx
+++ b/src/view/components/CustomEmbeddable.tsx
@@ -1,7 +1,10 @@
-import { ExcalidrawEmbeddableElement } from "@zsviczian/excalidraw/types/element/src/types";
+import {
+  ExcalidrawEmbeddableElement,
+} from "@zsviczian/excalidraw/types/element/src/types";
 import ExcalidrawView from "src/view/ExcalidrawView";
 import { Notice, requireApiVersion } from "obsidian";
 import * as React from "react";
+import clsx from "clsx";
 import { isObsidianThemeDark } from "src/utils/obsidianUtils";
 import {
   DEVICE,
@@ -1267,6 +1270,16 @@ export const CustomEmbeddable: React.FC<{
   const theme = getTheme(view, appState.theme);
   const mdProps: EmbeddableMDCustomProps = element.customData?.mdProps || null;
   const selectedElementIds = Object.keys(appState.selectedElementIds);
+  const hasPreviewBackedMarkdown = Boolean(
+    element.customData?.interactiveMarkdownPreviewBacked,
+  );
+  const isActive =
+    appState.activeEmbeddable?.element?.id === element.id &&
+    appState.activeEmbeddable?.state === "active";
+  const shouldPassThroughPreviewBackedMarkdown =
+    hasPreviewBackedMarkdown &&
+    !isActive &&
+    appState.activeTool?.type !== "selection";
   return (
     <div
       ref={containerRef}
@@ -1277,11 +1290,18 @@ export const CustomEmbeddable: React.FC<{
         color: `var(--text-normal)`,
         touchAction: "auto",
       }}
-      className={`${theme} canvas-node ${
-        mdProps?.filenameVisible && !mdProps.useObsidianDefaults
-          ? ""
-          : "excalidraw-mdEmbed-hideFilename"
-      }`}
+      className={clsx(
+        theme,
+        "canvas-node",
+        !(mdProps?.filenameVisible && !mdProps.useObsidianDefaults) &&
+          "excalidraw-mdEmbed-hideFilename",
+        hasPreviewBackedMarkdown && "excalidraw-md-embed-preview-backed",
+        hasPreviewBackedMarkdown &&
+          isActive &&
+          "excalidraw-md-embed-preview-active",
+        shouldPassThroughPreviewBackedMarkdown &&
+          "excalidraw-md-embed-preview-passthrough",
+      )}
     >
       <RenderObsidianView
         mdProps={mdProps}

--- a/styles.css
+++ b/styles.css
@@ -991,6 +991,19 @@ Obsidian Sheets Plus support
 End Obsidian Sheets Plus support
 */
 
+.excalidraw .excalidraw__embeddable-container .excalidraw-md-embed-preview-backed:not(.excalidraw-md-embed-preview-active) {
+  pointer-events: none;
+  visibility: hidden;
+}
+
+.excalidraw .excalidraw__embeddable-container:has(.excalidraw-md-embed-preview-passthrough) {
+  pointer-events: none;
+}
+
+.excalidraw .excalidraw__embeddable-container:has(.excalidraw-md-embed-preview-backed:not(.excalidraw-md-embed-preview-active)) .excalidraw__embeddable-hint {
+  display: none;
+}
+
 /* fixes: https://github.com/zsviczian/obsidian-excalidraw-plugin/issues/2789 */
 .excalidraw:not(.excalidraw--tray) .HintViewer {
   position: absolute;


### PR DESCRIPTION
## Summary
- add a backing image for interactive Markdown embeddables so freehand ink and other Excalidraw elements stay visible above the rendered Markdown preview
- hide/pass through the live Markdown embeddable when it is not active, while still allowing selection mode to activate it
- keep the backing image geometry and render size synchronized with the embeddable before save and after scene changes

## Validation
- npm run build
- git diff --check (only Windows line-ending warnings)
- Narrow leak scan on changed files

## Notes
- `npx eslint --max-warnings=0` on the changed files still reports existing repository lint issues unrelated to this patch, including pre-existing unsafe-any/no-console rules in the same files.
