### PR TITLE
Keep custom pen runtime state independent

### DIFF
--- a/src/view/components/menu/ObsidianMenu.tsx
+++ b/src/view/components/menu/ObsidianMenu.tsx
@@ -77,7 +77,7 @@ export function resetStrokeOptions(
 
 export class ObsidianMenu {
   private clickTimestamp: number[];
-  private activePen: PenStyle;
+  private activePens: Record<number, PenStyle> = {};
   private longpressTimeout: { [key: number]: number } = {};
   private prevClickTimestamp: number = 0;
   constructor(
@@ -119,8 +119,8 @@ export class ObsidianMenu {
     }
 
     //apply pen settings to canvas
-    this.activePen = { ...pen };
-    setPen(pen, api);
+    this.activePens[index] = this.activePens[index] ?? { ...pen };
+    setPen(this.activePens[index], api);
     api.setActiveTool({ type: "freedraw" });
   }
 
@@ -223,22 +223,26 @@ export class ObsidianMenu {
         pen.freedrawOnly
       ) {
         window.setTimeout(() =>
-          setPen(this.activePen, this.view.excalidrawAPI),
+          setPen(
+            this.activePens[index] ?? pen,
+            this.view.excalidrawAPI,
+          ),
         );
       }
 
       if (
-        this.activePen &&
         appState.resetCustomPen &&
         appState.activeTool.type === "freedraw" &&
         appState.currentStrokeOptions === pen.penOptions &&
         pen.freedrawOnly
       ) {
-        this.activePen.strokeWidth = appState.currentItemStrokeWidth;
-        this.activePen.backgroundColor = appState.currentItemBackgroundColor;
-        this.activePen.strokeColor = appState.currentItemStrokeColor;
-        this.activePen.fillStyle = appState.currentItemFillStyle;
-        this.activePen.roughness = appState.currentItemRoughness;
+        const activePen = this.activePens[index] ?? { ...pen };
+        activePen.strokeWidth = appState.currentItemStrokeWidth;
+        activePen.backgroundColor = appState.currentItemBackgroundColor;
+        activePen.strokeColor = appState.currentItemStrokeColor;
+        activePen.fillStyle = appState.currentItemFillStyle;
+        activePen.roughness = appState.currentItemRoughness;
+        this.activePens[index] = activePen;
       }
 
       return (
@@ -354,7 +358,7 @@ export class ObsidianMenu {
       this.view.ownerWindow.clearTimeout(t),
     );
     this.longpressTimeout = {};
-    this.activePen = null;
+    this.activePens = {};
     this.plugin = null;
     this.toolsRef = null;
     this.view = null;


### PR DESCRIPTION
## Summary
- keep runtime custom pen settings per custom pen index instead of sharing one active pen object
- switching between custom pens restores each pen's last adjusted stroke width, colors, fill style, and roughness
- clear the per-pen runtime cache when the Obsidian menu is destroyed

## Validation
- npm run build
- git diff --check (only Windows line-ending warnings)
- Narrow leak scan on changed file

## Notes
- `npx eslint --max-warnings=0 src/view/components/menu/ObsidianMenu.tsx` still reports existing repository lint issues in that file unrelated to this patch.
