### PR TITLE
fix(i18n): expose unpackBase64Deflate on window for locale loading

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -151,6 +151,7 @@ const packageString = isLib
   '  for (let i = 0; i < len; i++) bytes[i] = binStr.charCodeAt(i);\n' +
   '  return new TextDecoder().decode(pako.inflate(bytes));\n' +
   '};\n' +
+  'window.unpackBase64Deflate = unpackBase64Deflate;\n' +
   'const unpackExcalidraw = () => unpackBase64Deflate("' + compressDeflateBase64(excalidraw_pkg) + '");\n' +
   'let {react, reactDOM } = new Function(`${REACT_PACKAGES}; return {react: React, reactDOM: ReactDOM};`)();\n' +
   'let excalidrawLib = {};\n' +


### PR DESCRIPTION
## Summary

Non-English locale packs fail to load, causing the entire Excalidraw settings UI to render in English even when Obsidian is configured to use another language.

It was reproduced with:

* Obsidian language: Simplified Chinese
* Excalidraw version: `2.24.1`

## Root Cause

`loadLocale()` expects to read `unpackBase64Deflate` from `window`, but the Rollup banner only defines it as a local `const` and never exposes it globally.

As a result, `window.unpackBase64Deflate` is `undefined`, so `loadLocale()` always falls back to English before loading any non-English locale.

## Fix

Expose `unpackBase64Deflate` on `window` in the Rollup banner immediately after its definition:

```ts
'window.unpackBase64Deflate = unpackBase64Deflate;\n' +
```
