### PR TITLE
Lock embeedable reading mode, polybool, popout freeze

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@popperjs/core": "^2.11.8",
         "@radix-ui/number": "^1.1.2",
         "@zsviczian/colormaster": "^1.2.2",
-        "@zsviczian/excalidraw": "0.18.105",
+        "@zsviczian/excalidraw": "0.18.106",
         "chroma-js": "^3.1.2",
         "clsx": "^2.0.0",
         "es6-promise-pool": "2.5.0",
@@ -5232,9 +5232,9 @@
       "license": "MIT"
     },
     "node_modules/@zsviczian/excalidraw": {
-      "version": "0.18.105",
-      "resolved": "https://registry.npmjs.org/@zsviczian/excalidraw/-/excalidraw-0.18.105.tgz",
-      "integrity": "sha512-SOwKicgUPuz2rgOGGmAK3uuespob7knGoriHo82dfVrPT4eM1WhFNiDbGpnWql+PdkhwHrLG4ZcGpiXxAv/kRw==",
+      "version": "0.18.106",
+      "resolved": "https://registry.npmjs.org/@zsviczian/excalidraw/-/excalidraw-0.18.106.tgz",
+      "integrity": "sha512-0aTjZkHCixllxN6gEnqklrBERcqHsuL5rGjzp0BUW/5KvduF/ZNS7oyBVKm+sK9l+TPlIKbMku+jxSu0eWOlQA==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@popperjs/core": "^2.11.8",
     "@radix-ui/number": "^1.1.2",
     "@zsviczian/colormaster": "^1.2.2",
-    "@zsviczian/excalidraw": "0.18.105",
+    "@zsviczian/excalidraw": "0.18.106",
     "chroma-js": "^3.1.2",
     "clsx": "^2.0.0",
     "es6-promise-pool": "2.5.0",

--- a/src/constants/actionIcons.tsx
+++ b/src/constants/actionIcons.tsx
@@ -213,6 +213,8 @@ export const ICONS = {
       </text>
     </svg>
   ),
+  Edit: getIconAsJSX("pen-line"),
+  Read: getIconAsJSX("book-open"),
   Learn: getIconAsJSX("graduation-cap"),
   Github: getIconAsJSX("github"),
   YouTube: getIconAsJSX("youtube"),

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -748,6 +748,7 @@ export const DEFAULT_SETTINGS: ExcalidrawSettings = {
     borderColor: "#fff",
     borderOpacity: 0,
     filenameVisible: false,
+    lockedReadingMode: false,
   },
   markdownNodeOneClickEditing: false,
   canvasImmersiveEmbed: true,

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -1290,6 +1290,10 @@ export default {
   ES_YOUTUBE_START_INVALID:
     "The YouTube Start Time is invalid. Please check the format and try again",
   ES_FILENAME_VISIBLE: "Filename Visible",
+  ES_LOCKED_READING_MODE_HEAD: "Locked Reading Mode",
+  ES_LOCKED_READING_MODE_DESC: "When enabled, interacting with the markdown embeddable will not switch it to edit mode. This is useful for checklists and habit trackers.",
+  LOCK_READING_MODE: "Lock Reading Mode",
+  UNLOCK_READING_MODE: "Unlock Reading Mode",
   ES_BACKGROUND_HEAD: "Embedded note background color",
   ES_BACKGROUND_DESC_INFO: "Click here for more info on colors",
   ES_BACKGROUND_DESC_DETAIL:

--- a/src/shared/Dialogs/EmbeddableMDFileCustomDataSettingsComponent.ts
+++ b/src/shared/Dialogs/EmbeddableMDFileCustomDataSettingsComponent.ts
@@ -53,7 +53,19 @@ export class EmbeddalbeMDFileCustomDataSettingsComponent {
               this.mdCustomData.filenameVisible = value;
             }),
         );
+
+      new Setting(contentEl)
+        .setName(t("ES_LOCKED_READING_MODE_HEAD"))
+        .setDesc(t("ES_LOCKED_READING_MODE_DESC"))
+        .addToggle((toggle) =>
+          toggle
+            .setValue(this.mdCustomData.lockedReadingMode ?? false)
+            .onChange((value) => {
+              this.mdCustomData.lockedReadingMode = value;
+            }),
+      );
     }
+    
     contentEl.createEl("h4", { text: t("ES_BACKGROUND_HEAD") });
     const descDiv = contentEl.createDiv({ cls: "excalidraw-setting-desc" });
     descDiv.textContent = t("ES_BACKGROUND_DESC_INFO");

--- a/src/shared/Dialogs/EmbeddableSettings.ts
+++ b/src/shared/Dialogs/EmbeddableSettings.ts
@@ -32,6 +32,7 @@ export type EmbeddableMDCustomProps = {
   borderColor: string;
   borderOpacity: number;
   filenameVisible: boolean;
+  lockedReadingMode?: boolean;
 };
 
 export class EmbeddableSettings extends Modal {
@@ -67,8 +68,8 @@ export class EmbeddableSettings extends Modal {
     }
 
     this.mdCustomData =
-      element.customData?.mdProps ??
-      view.plugin.settings.embeddableMarkdownDefaults;
+      (element.customData?.mdProps ??
+      view.plugin.settings.embeddableMarkdownDefaults) as EmbeddableMDCustomProps;
     if (!element.customData?.mdProps) {
       const bgCM = this.plugin.ea.getCM(element.backgroundColor);
       this.mdCustomData.backgroundColor = bgCM.stringHEX({ alpha: false });

--- a/src/shared/Dialogs/Messages.ts
+++ b/src/shared/Dialogs/Messages.ts
@@ -17,6 +17,13 @@ I build this plugin as a labor of love. Curious about the philosophy behind it? 
 
 <div class="ex-coffee-div"><a href="${URLs.KO_FI_COM_ZSOLT}"><img src="${URLs.CDN_KO_FI_COM_CDN_KOFI3_PNG}" border="0" alt="Buy Me a Coffee at ko-fi.com"  height=45></a></div>
 `,
+  ".24.2": `
+  ## Fixed
+  - Regression in 2.24.0: Translations were not loading correctly. 🙏[@Lumintian](${URLs.GITHUB_COM}/Lumintian) [#2809](${URLs.GITHUB_COM_ZSVICZIAN_OBSIDIAN_EXCALIDRAW_PLUGIN_PULL}/2809)
+
+  ## New
+  - Added lock reading mode to markdown embeddables. If reading mode is locked, clicking the embeddable will not switch to the editor. This is useful for interacting with todo lists, links, and other interactive elements in the embeddables. Based on feedback from the Sketch Your Mind Community. 🙏[@robb3r](${URLs.COMMUNITY_SKETCH_YOUR_MIND_COM}/u/robb3r)
+`,
   "2.24.1": `
 To keep Excalidraw lightweight, improve startup performance, reduce plugin size, and address Obsidian's high-risk code scanner findings, several advanced features have been moved to the new **Excalidraw Extras** companion plugin in 2.24.0.
 

--- a/src/shared/ExcalidrawAutomate.ts
+++ b/src/shared/ExcalidrawAutomate.ts
@@ -4838,6 +4838,10 @@ export class ExcalidrawAutomate {
   getPolyBool(): typeof PolyBool {
     const defaultEpsilon = 0.0000000001;
     PolyBool.epsilon(defaultEpsilon);
+
+    if ("buildLog" in PolyBool) {
+      PolyBool.buildLog(false);
+    }
     return PolyBool;
   }
 

--- a/src/types/polybooljs.d.ts
+++ b/src/types/polybooljs.d.ts
@@ -1,6 +1,7 @@
 declare module "polybooljs" {
   interface PolyBoolStatic {
     epsilon(value: number): void;
+    buildLog(value: boolean): void;
   }
 
   const PolyBool: PolyBoolStatic;

--- a/src/utils/ExcalidrawExtrasGateway.ts
+++ b/src/utils/ExcalidrawExtrasGateway.ts
@@ -13,7 +13,7 @@ const REQUIRED_EXTRAS_VERSIONS: Record<
   string,
   { min?: string; exact?: string }
 > = {
-  plugin: { min: "0.0.13" },
+  plugin: { min: "0.0.14" },
   mathjax: { min: "1.0.0" },
   mermaid: { exact: "2.2.2" },
   pdf: { min: "1.0.0" },

--- a/src/view/ExcalidrawView.ts
+++ b/src/view/ExcalidrawView.ts
@@ -1674,6 +1674,9 @@ export default class ExcalidrawView
   }
 
   exitFullscreen() {
+    if (!this.isFullscreen()) {
+      return;
+    }
     if (this.toolsPanelRef && this.toolsPanelRef.current) {
       this.toolsPanelRef.current.setFullscreen(false);
     }
@@ -2731,6 +2734,8 @@ export default class ExcalidrawView
     //I noticed Obsidian calls this function twice when disabling the plugin
     //once from "unregisterView"
     //the from "detachLeavesOfType"
+    this.clearPreventReloadTimer();
+    this.clearEmbeddableNodeIsEditingTimer();
     if (!this.dropManager && !this.excalidrawRoot) {
       return;
     } //the view is already closed
@@ -2750,8 +2755,6 @@ export default class ExcalidrawView
       this.excalidrawRoot = null;
     }
 
-    this.clearPreventReloadTimer();
-    this.clearEmbeddableNodeIsEditingTimer();
     this.cancelDeferredSceneFileValidation();
     if (this.activeLoader) {
       this.activeLoader.terminate = true;

--- a/src/view/components/CustomEmbeddable.tsx
+++ b/src/view/components/CustomEmbeddable.tsx
@@ -572,11 +572,18 @@ function RenderObsidianView({
   const pdfObserverDisabledRef = React.useRef(false);
   const mobilePatchCleanupRef = React.useRef(null);
   const initialViewFileRef = React.useRef(view.file);
+  const mdPropsRef = React.useRef(mdProps);
+  const fileRef = React.useRef(file);
 
   // Update themeRef when theme changes
   React.useEffect(() => {
     themeRef.current = theme;
   }, [theme]);
+  
+  React.useEffect(() => {
+    mdPropsRef.current = mdProps;
+    fileRef.current = file;
+  }, [mdProps, file]);
 
   //--------------------------------------------------------------------------------
   //block propagation of events to the parent if the embeddable element is active
@@ -695,6 +702,22 @@ function RenderObsidianView({
         containerRef.current,
         element.id,
       );
+
+      // --- PATCH NATIVE OBSIDIAN CANVAS NODE ---
+      // Obsidian's native canvas event listeners will force the node into edit mode
+      // on certain clicks/double-clicks. This intercepts Obsidian's core method.
+      const node = leafRef.current.node;
+      if (node && typeof node.startEditing === "function") {
+        const originalStartEditing = node.startEditing;
+        node.startEditing = function (...args: unknown[]) {
+          // Read directly from the ref to ensure dynamic lock toggling works
+          if (mdPropsRef.current?.lockedReadingMode) {
+            return;
+          }
+          return originalStartEditing.apply(this, args) as unknown;
+        };
+      }
+
       setColors(containerRef.current, element, mdProps, canvasColor, viewType);
       view.updateEmbeddableLeafRef(element.id, leafRef.current);
       viewTypeRef.current = "markdown";
@@ -1047,7 +1070,7 @@ function RenderObsidianView({
   //--------------------------------------------------------------------------------
   //Switch to edit mode when markdown view is clicked
   //--------------------------------------------------------------------------------
-    const handleClick = React.useCallback(
+  const handleClick = React.useCallback(
     (event?: Event) => {
       if (view.file !== initialViewFileRef.current) {
         return;
@@ -1061,10 +1084,13 @@ function RenderObsidianView({
         return;
       }
 
-      if (mdProps?.lockedReadingMode) {
+      const currentMdProps = mdPropsRef.current;
+      const currentFile = fileRef.current;
+
+      if (currentMdProps?.lockedReadingMode) {
         // Special case: if the card is a back-of-the-note card, ticking a checkbox in 
         // reading mode triggers a change to the open file which would result in a view update.
-        if (file.path === view.file.path) {
+        if (currentFile?.path === view.file.path) {
           view.setPreventReload();
           void view.setEmbeddableNodeIsEditing();
         }
@@ -1113,8 +1139,6 @@ function RenderObsidianView({
       isActiveRef.current,
       isEditingRef.current,
       viewTypeRef.current,
-      mdProps?.lockedReadingMode,
-      file.path,
     ],
   );
 
@@ -1172,7 +1196,7 @@ function RenderObsidianView({
   //--------------------------------------------------------------------------------
   // Set isActiveRef and switch to preview mode when the embeddable is not active
   //--------------------------------------------------------------------------------
-    React.useEffect(() => {
+  React.useEffect(() => {
     if (view.file !== initialViewFileRef.current) {
       return;
     }
@@ -1202,8 +1226,8 @@ function RenderObsidianView({
         view.plugin.settings.markdownNodeOneClickEditing &&
         !containerRef.current?.hasClass("is-editing")
       ) {
-        if (mdProps?.lockedReadingMode) {
-          if (file.path === view.file.path) {
+        if (mdPropsRef.current?.lockedReadingMode) {
+          if (fileRef.current?.path === view.file.path) {
             view.setPreventReload();
             void view.setEmbeddableNodeIsEditing();
           }
@@ -1264,7 +1288,6 @@ function RenderObsidianView({
     activeEmbeddable?.state,
     isActiveRef,
     activeEmbeddable?.element,
-    activeEmbeddable?.state,
     element,
     view,
     isEditingRef,

--- a/src/view/components/CustomEmbeddable.tsx
+++ b/src/view/components/CustomEmbeddable.tsx
@@ -552,7 +552,7 @@ function RenderObsidianView({
   canvasColor: string;
   selectedElementId: string;
   sceneZoom: number;
-}): JSX.Element {
+}): React.JSX.Element {
   const { subpath, file } = processLinkText(linkText, view);
 
   if (!file) {
@@ -1047,7 +1047,7 @@ function RenderObsidianView({
   //--------------------------------------------------------------------------------
   //Switch to edit mode when markdown view is clicked
   //--------------------------------------------------------------------------------
-  const handleClick = React.useCallback(
+    const handleClick = React.useCallback(
     (event?: Event) => {
       if (view.file !== initialViewFileRef.current) {
         return;
@@ -1058,6 +1058,16 @@ function RenderObsidianView({
       }
 
       if (!isActiveRef.current || isEditingRef.current || !leafRef.current) {
+        return;
+      }
+
+      if (mdProps?.lockedReadingMode) {
+        // Special case: if the card is a back-of-the-note card, ticking a checkbox in 
+        // reading mode triggers a change to the open file which would result in a view update.
+        if (file.path === view.file.path) {
+          view.setPreventReload();
+          void view.setEmbeddableNodeIsEditing();
+        }
         return;
       }
 
@@ -1103,6 +1113,8 @@ function RenderObsidianView({
       isActiveRef.current,
       isEditingRef.current,
       viewTypeRef.current,
+      mdProps?.lockedReadingMode,
+      file.path,
     ],
   );
 
@@ -1160,7 +1172,7 @@ function RenderObsidianView({
   //--------------------------------------------------------------------------------
   // Set isActiveRef and switch to preview mode when the embeddable is not active
   //--------------------------------------------------------------------------------
-  React.useEffect(() => {
+    React.useEffect(() => {
     if (view.file !== initialViewFileRef.current) {
       return;
     }
@@ -1190,10 +1202,17 @@ function RenderObsidianView({
         view.plugin.settings.markdownNodeOneClickEditing &&
         !containerRef.current?.hasClass("is-editing")
       ) {
-        //!node.isEditing
-        const newTheme = getTheme(view, themeRef.current);
-        containerRef.current?.addClasses(["is-editing", "is-focused"]);
-        void view.canvasNodeFactory.startEditing(node, newTheme);
+        if (mdProps?.lockedReadingMode) {
+          if (file.path === view.file.path) {
+            view.setPreventReload();
+            void view.setEmbeddableNodeIsEditing();
+          }
+        } else {
+          //!node.isEditing
+          const newTheme = getTheme(view, themeRef.current);
+          containerRef.current?.addClasses(["is-editing", "is-focused"]);
+          void view.canvasNodeFactory.startEditing(node, newTheme);
+        }
       } else {
         containerRef.current?.removeClasses(["is-editing", "is-focused"]);
         view.canvasNodeFactory.stopEditing(node);
@@ -1251,6 +1270,8 @@ function RenderObsidianView({
     isEditingRef,
     view.canvasNodeFactory,
     themeRef.current,
+    mdProps?.lockedReadingMode,
+    file.path,
   ]);
 
   return null;

--- a/src/view/components/CustomEmbeddable.tsx
+++ b/src/view/components/CustomEmbeddable.tsx
@@ -574,6 +574,7 @@ function RenderObsidianView({
   const initialViewFileRef = React.useRef(view.file);
   const mdPropsRef = React.useRef(mdProps);
   const fileRef = React.useRef(file);
+  const prevLockRef = React.useRef(mdProps?.lockedReadingMode);
 
   // Update themeRef when theme changes
   React.useEffect(() => {
@@ -1210,7 +1211,10 @@ function RenderObsidianView({
       activeEmbeddable?.element.id === element.id &&
       activeEmbeddable?.state === "active";
 
-    if (previousIsActive === isActiveRef.current) {
+    const lockChanged = prevLockRef.current !== mdProps?.lockedReadingMode;
+    prevLockRef.current = !!mdProps?.lockedReadingMode;
+
+    if (previousIsActive === isActiveRef.current && !lockChanged) {
       return;
     }
 
@@ -1240,6 +1244,7 @@ function RenderObsidianView({
       } else {
         containerRef.current?.removeClasses(["is-editing", "is-focused"]);
         view.canvasNodeFactory.stopEditing(node);
+        view.clearEmbeddableNodeIsEditing();
       }
       return;
     }

--- a/src/view/components/menu/EmbeddableActionsMenu.tsx
+++ b/src/view/components/menu/EmbeddableActionsMenu.tsx
@@ -26,7 +26,7 @@ import {
 } from "src/utils/customEmbeddableUtils";
 import { getActivePDFPageNumberFromPDFView } from "src/utils/obsidianUtils";
 import { cleanSectionHeading } from "src/utils/pathUtils";
-import { EmbeddableSettings } from "src/shared/Dialogs/EmbeddableSettings";
+import { EmbeddableSettings, EmbeddableMDCustomProps } from "src/shared/Dialogs/EmbeddableSettings";
 import {
   insertImageToView,
   openExternalLink,
@@ -109,7 +109,7 @@ export class EmbeddableMenu {
     const app = view.app;
     element = view.excalidrawAPI
       .getSceneElements()
-      .find((e: ExcalidrawElement) => e.id === element.id);
+      .find((e: ExcalidrawElement) => e.id === element.id) as ExcalidrawEmbeddableElement;
     if (!element) {
       return;
     }
@@ -364,6 +364,29 @@ export class EmbeddableMenu {
     );
   }
 
+  private async actionToggleLockReadingMode(
+    element: ExcalidrawEmbeddableElement,
+  ) {
+    if (!element) {
+      return;
+    }
+    const mdProps = (element.customData?.mdProps as EmbeddableMDCustomProps) ?? this.view.plugin.settings.embeddableMarkdownDefaults;
+    const isLocked = mdProps.lockedReadingMode ?? false;
+    
+    const ea = getEA(this.view);
+    ea.copyViewElementsToEAforEditing([element]);
+    const eaEl = ea.getElement(element.id);
+    eaEl.customData = { 
+      ...(eaEl.customData || {}), 
+      mdProps: {
+        ...mdProps,
+        lockedReadingMode: !isLocked
+      } 
+    };
+    await ea.addElementsToView(false, true, true);
+    ea.destroy();
+  }
+
   private actionProperties(element: ExcalidrawEmbeddableElement, file: TFile) {
     if (!element) {
       return;
@@ -472,6 +495,8 @@ export class EmbeddableMenu {
         );
         const top = `${y - 2.5 * ROOTELEMENTSIZE - appState.offsetTop}px`;
         const left = `${x - appState.offsetLeft}px`;
+        const mdProps = (element.customData?.mdProps as EmbeddableMDCustomProps) ?? view.plugin.settings.embeddableMarkdownDefaults;
+        const isLockedReadingMode = mdProps.lockedReadingMode ?? false;
 
         return (
           <div
@@ -528,6 +553,17 @@ export class EmbeddableMenu {
                   icon={ICONS.ZoomToBlock}
                 />
               )}
+
+              {isMD && !isExcalidrawFile && (
+                <ActionButton
+                  key="LockReadingMode"
+                  title={isLockedReadingMode ? t("UNLOCK_READING_MODE") : t("LOCK_READING_MODE")}
+                  action={() =>
+                    void this.actionToggleLockReadingMode(element)
+                  }
+                  icon={isLockedReadingMode ? ICONS.Edit : ICONS.Read}
+                />
+              )}
               <ActionButton
                 key={"ZoomToElement"}
                 title={t("ZOOM_TO_FIT")}
@@ -570,9 +606,9 @@ export class EmbeddableMenu {
       }
     }
     if (isObsidianiFrame || isExcalidrawiFrame) {
-      const iframe = isExcalidrawiFrame
+      const iframe = (isExcalidrawiFrame
         ? api.getHTMLIFrameElement(element.id)
-        : view.getEmbeddableElementById(element.id);
+        : view.getEmbeddableElementById(element.id)) as HTMLIFrameElement;
       if (!iframe || !iframe.contentWindow) {
         return null;
       }

--- a/src/view/components/menu/EmbeddableActionsMenu.tsx
+++ b/src/view/components/menu/EmbeddableActionsMenu.tsx
@@ -35,6 +35,7 @@ import { getEA } from "src/core";
 import { CaptureUpdateAction } from "src/constants/constants";
 import { URLs } from "src/constants/safeUrls";
 import { setStyle } from "src/utils/styleUtils";
+import { addAppendUpdateCustomData } from "src/utils/elementCustomDataUtils";
 
 type BlockCacheEntry = Awaited<
   ReturnType<ExcalidrawView["app"]["metadataCache"]["blockCache"]["getForFile"]>
@@ -371,20 +372,31 @@ export class EmbeddableMenu {
       return;
     }
     const mdProps = (element.customData?.mdProps as EmbeddableMDCustomProps) ?? this.view.plugin.settings.embeddableMarkdownDefaults;
-    const isLocked = mdProps.lockedReadingMode ?? false;
+    const isLocked = !!mdProps.lockedReadingMode;
+    mdProps.lockedReadingMode = !isLocked;
     
     const ea = getEA(this.view);
     ea.copyViewElementsToEAforEditing([element]);
     const eaEl = ea.getElement(element.id);
-    eaEl.customData = { 
-      ...(eaEl.customData || {}), 
-      mdProps: {
-        ...mdProps,
-        lockedReadingMode: !isLocked
-      } 
-    };
-    await ea.addElementsToView(false, true, true);
+    addAppendUpdateCustomData(eaEl, mdProps);
+    await ea.addElementsToView();
     ea.destroy();
+
+    // Fetch the updated element reference from the scene
+    const api = this.view.excalidrawAPI;
+    const updatedElement = api.getSceneElements().find((e: ExcalidrawElement) => e.id === element.id) as ExcalidrawEmbeddableElement;
+
+    // Force an appState update so the React menu component re-renders
+    if (updatedElement) {
+      this.view.updateScene({
+        appState: {
+          activeEmbeddable: {
+            element: updatedElement,
+            state: "active"
+          }
+        }
+      });
+    }
   }
 
   private actionProperties(element: ExcalidrawEmbeddableElement, file: TFile) {
@@ -496,7 +508,7 @@ export class EmbeddableMenu {
         const top = `${y - 2.5 * ROOTELEMENTSIZE - appState.offsetTop}px`;
         const left = `${x - appState.offsetLeft}px`;
         const mdProps = (element.customData?.mdProps as EmbeddableMDCustomProps) ?? view.plugin.settings.embeddableMarkdownDefaults;
-        const isLockedReadingMode = mdProps.lockedReadingMode ?? false;
+        const isLockedReadingMode = !!mdProps.lockedReadingMode;
 
         return (
           <div
@@ -553,8 +565,7 @@ export class EmbeddableMenu {
                   icon={ICONS.ZoomToBlock}
                 />
               )}
-
-              {isMD && !isExcalidrawFile && (
+              {isMD && (
                 <ActionButton
                   key="LockReadingMode"
                   title={isLockedReadingMode ? t("UNLOCK_READING_MODE") : t("LOCK_READING_MODE")}

--- a/styles.css
+++ b/styles.css
@@ -2,15 +2,15 @@
   height: 100%;
   margin: 0px;
   background-color: var(--background-primary);
-  position:relative;
+  position: relative;
 }
 
 .block-language-excalidraw {
-  text-align:center;
+  text-align: center;
 }
 
 svg.excalidraw-svg {
-	width: 100%;
+  width: 100%;
 }
 
 .excalidraw-embedded-img {
@@ -50,7 +50,7 @@ div.excalidraw-svg-left {
 }
 
 button.ToolIcon_type_button[title="Export"] {
-  display:none;
+  display: none;
 }
 
 .excalidraw-prompt-div {
@@ -104,8 +104,8 @@ button.ToolIcon_type_button[title="Export"] {
 }
 
 .ex-coffee-div {
-	text-align: center;
-	margin-bottom: 10px;
+  text-align: center;
+  margin-bottom: 10px;
 }
 
 .excalidraw-mastery-promo {
@@ -196,7 +196,7 @@ button.ToolIcon_type_button[title="Export"] {
 
 .excalidraw-scriptengine-install td>img {
   width: 100%;
-  max-width:800px;
+  max-width: 800px;
 }
 
 .excalidraw-scriptengine-install img.coffee {
@@ -227,7 +227,7 @@ button.ToolIcon_type_button[title="Export"] {
 }
 
 .excalidraw-scriptengine-install .modal {
-  max-height:90%;
+  max-height: 90%;
   width: auto;
 }
 
@@ -250,18 +250,20 @@ button.ToolIcon_type_button[title="Export"] {
 }
 
 .workspace-leaf-content .excalidraw-view {
-  padding: 0px 1px; /*1px so on ipad swipe in from left and right still works*/
+  padding: 0px 1px;
+  /*1px so on ipad swipe in from left and right still works*/
   overflow: hidden;
 }
 
 .excalidraw-videoWrapper {
-  max-width:600px;
-}
-.excalidraw-videoWrapper.settings {
-  max-width:340px;
+  max-width: 600px;
 }
 
-.excalidraw-videoWrapper div{
+.excalidraw-videoWrapper.settings {
+  max-width: 340px;
+}
+
+.excalidraw-videoWrapper div {
   position: relative;
   padding-bottom: 56.25%;
   height: 0;
@@ -281,7 +283,7 @@ button.ToolIcon_type_button[title="Export"] {
   height: 100%;
 }
 
-.excalidraw-release .modal-content{
+.excalidraw-release .modal-content {
   padding-right: 5px;
   margin-right: -5px;
   user-select: text;
@@ -293,7 +295,7 @@ button.ToolIcon_type_button[title="Export"] {
 }
 
 .excalidraw-scriptengine-install tbody>tr>td>div>img {
-  height:20px;
+  height: 20px;
   background-color: silver;
   padding: 2px;
 }
@@ -318,7 +320,7 @@ button.ToolIcon_type_button[title="Export"] {
   position: absolute;
   padding: 12px;
   border-radius: 10px;
-  box-shadow: 0 8px 24px rgba(0,0,0,0.25);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
   background-color: var(--background-primary);
   border: 1px solid var(--background-modifier-border);
   z-index: 9999;
@@ -347,18 +349,13 @@ textarea.excalidraw-wysiwyg {
   -webkit-box-shadow: none;
   -moz-box-shadow: none;
   box-shadow: none;
-  border-radius: 0;  
+  border-radius: 0;
 }
 
 .is-tablet .excalidraw button,
 .is-mobile .excalidraw button {
   padding: initial;
   height: 1.8rem;
-}
-
-.excalidraw-hidden,
-.excalidraw-display-none {
-  display: none !important;
 }
 
 .excalidraw-display-flex {
@@ -378,7 +375,7 @@ textarea.excalidraw-wysiwyg {
   background: var(--background-primary-alt);
 }
 
-.excalidraw-ai-provider-table > .setting-item {
+.excalidraw-ai-provider-table>.setting-item {
   margin-top: 0;
   margin-bottom: 0;
   padding-bottom: 0.5rem;
@@ -396,7 +393,7 @@ textarea.excalidraw-wysiwyg {
   min-height: 0;
 }
 
-.excalidraw-ai-provider-table__row + .excalidraw-ai-provider-table__row {
+.excalidraw-ai-provider-table__row+.excalidraw-ai-provider-table__row {
   border-top: 1px solid var(--background-modifier-border);
 }
 
@@ -506,7 +503,8 @@ div.excalidraw-draginfo {
   padding: 0.5rem;
 }
 
-.excalidraw-sidepanel-tab__button { /* probably unused */
+.excalidraw-sidepanel-tab__button {
+  /* probably unused */
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
@@ -680,7 +678,7 @@ img.excalidraw-cropped-pdfpage,
   opacity: 0;
 }
 
-.popover .excalidraw-svg {  
+.popover .excalidraw-svg {
   width: 100%;
   max-width: inherit;
   height: 100%;
@@ -688,24 +686,26 @@ img.excalidraw-cropped-pdfpage,
 }
 
 root {
- --excalidraw-caret-color: initial;
+  --excalidraw-caret-color: initial;
 }
 
 .excalidraw-settings-links-container {
-    align-items: center;
-    color: inherit;
-    display: flex;
-    gap: .3em;
-    text-align: center;
-    text-decoration: none;
-    flex-wrap: wrap;
-    justify-content: center;
-    flex-direction: row;
+  align-items: center;
+  color: inherit;
+  display: flex;
+  gap: .3em;
+  text-align: center;
+  text-decoration: none;
+  flex-wrap: wrap;
+  justify-content: center;
+  flex-direction: row;
 }
 
 .excalidraw-settings-links-container a {
-  display: flex; /* Align children horizontally */
-  align-items: center; /* Center items vertically */
+  display: flex;
+  /* Align children horizontally */
+  align-items: center;
+  /* Center items vertically */
   text-align: left;
   margin-right: 4px;
   margin-left: 4px;
@@ -761,19 +761,14 @@ root {
   margin-bottom: -2px;
 }
 
-.is-mobile .modal-container.excalidraw-modal .modal.excalidraw-modal {
-  align-self: flex-start;
-  transform: none !important;
-  margin-top: calc(var(--safe-area-inset-top) + var(--header-height) + var(--size-4-2));
-  width: 100%;
-}
-
 .excalidraw-prompt-buttonbar-top,
 .excalidraw-prompt-buttonbar-bottom {
   display: flex;
   flex-wrap: wrap;
-  align-items: flex-start;  /* keep both rows top‐aligned */
-  row-gap: 0.5em;           /* vertical space when wrapped */
+  align-items: flex-start;
+  /* keep both rows top‐aligned */
+  row-gap: 0.5em;
+  /* vertical space when wrapped */
 }
 
 /* top bar specifics */
@@ -788,20 +783,20 @@ root {
 }
 
 /* make each child a flex row */
-.excalidraw-prompt-buttonbar-top  > div,
-.excalidraw-prompt-buttonbar-bottom > div {
+.excalidraw-prompt-buttonbar-top>div,
+.excalidraw-prompt-buttonbar-bottom>div {
   display: flex;
 }
 
 /* push the first group to the left */
-.excalidraw-prompt-buttonbar-top  > div:first-child,
-.excalidraw-prompt-buttonbar-bottom > div:first-child {
+.excalidraw-prompt-buttonbar-top>div:first-child,
+.excalidraw-prompt-buttonbar-bottom>div:first-child {
   margin-right: auto;
 }
 
 /* push the second group to the right */
-.excalidraw-prompt-buttonbar-top  > div:last-child,
-.excalidraw-prompt-buttonbar-bottom > div:last-child {
+.excalidraw-prompt-buttonbar-top>div:last-child,
+.excalidraw-prompt-buttonbar-bottom>div:last-child {
   margin-left: auto;
 }
 
@@ -810,7 +805,7 @@ root {
   flex-direction: column;
   background: var(--background-secondary);
   border-radius: 8px;
-  box-shadow: 0 1px 4px 0 rgba(0,0,0,0.10);
+  box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.10);
   padding: 0.5em 0.8em;
   margin-bottom: 0.5em;
   max-width: calc(100% - 1.6em);
@@ -885,7 +880,8 @@ root {
   justify-content: center;
 }
 
-.excalidraw-search .document-search-button:hover, .excalidraw-search .document-search-button:focus {
+.excalidraw-search .document-search-button:hover,
+.excalidraw-search .document-search-button:focus {
   background: var(--background-modifier-hover);
   color: var(--text-accent);
 }
@@ -898,69 +894,8 @@ root {
   pointer-events: none;
 }
 
-.excalidraw-LatexPrompt {
-  .cm-editor {
-    margin-top: var(--size-4-2);
-    justify-content: center;
-    align-items: center;
-
-    /* this is safe, if unsupported, will be ignored */
-    anchor-name: --latex-editor;
-
-    & > .cm-scroller, & > .cm-announcment {
-      align-self: start;
-      width: 100%
-    }
-
-    /* taken from Obsidian, doesn't apply automatically,
-       because the rule does not have :focus-within */
-    &.cm-focused {
-      border-color: var(--background-modifier-border-focus);
-      transition: box-shadow 0.15s ease-in-out, border 0.15s ease-in-out;
-      box-shadow: 0 0 0 var(--input-border-width-focus) var(--background-modifier-border-focus);
-    }
-
-    /* centering the popup */
-    & .cm-tooltip-cursor.cm-tooltip {
-      left: unset !important;
-
-      & .cm-tooltip-arrow {
-        left: 50% !important;
-        transform: translateX(-50%);
-      }
-    }
-
-    [jax="CHTML"][display="true"] {
-      margin: 0;
-    }
-  }
-
-  .cm-content {
-    caret-color: var(--caret-color);
-  }
-}
-
-@supports (anchor-name: --test) {
-  .excalidraw-LatexPrompt .cm-editor .cm-tooltip-cursor.cm-tooltip {
-    position: fixed !important;
-    position-anchor: --latex-editor;
-    top: unset !important;
-    max-width: calc(100vw - var(--size-4-4));
-    margin: var(--size-4-2) 0;
-    overflow-x: clip;
-
-    &.cm-tooltip-above {
-      bottom: anchor(top);
-    }
-
-    &.cm-tooltip-below {
-      top: anchor(bottom) !important;
-    }
-  }
-}
-
 .excalidraw-filetype-tag {
-    order: 99;
+  order: 99;
 }
 
 .excalidraw-mobile-navbar-docked {
@@ -975,16 +910,16 @@ root {
 Obsidian Sheets Plus support
 */
 .excalidraw__embeddable__outer .lj-content-view {
-	width: var(--embeddable-width);
-	height: var(--embeddable-height);
+  width: var(--embeddable-width);
+  height: var(--embeddable-height);
 }
 
 .excalidraw__embeddable__outer #sheet-box {
-	height: calc(var(--embeddable-height) - var(--lj-toolbar-height) + 40px);
+  height: calc(var(--embeddable-height) - var(--lj-toolbar-height) + 40px);
 }
 
 .excalidraw__embeddable__outer .lj-univer .univer-relative.univer-grid {
-    width: var(--embeddable-width);
+  width: var(--embeddable-width);
 }
 
 /*
@@ -997,16 +932,18 @@ End Obsidian Sheets Plus support
 }
 
 .excalidraw-button-bgcolor {
-  &-normal { 
-    background-color: var(--interactive-normal); 
+  &-normal {
+    background-color: var(--interactive-normal);
     color: var(--text-normal);
   }
-  &-accent { 
-    background-color: var(--interactive-accent); 
+
+  &-accent {
+    background-color: var(--interactive-accent);
     color: var(--text-on-accent);
   }
-  &-success { 
-    background-color: var(--interactive-success); 
+
+  &-success {
+    background-color: var(--interactive-success);
     color: var(--text-on-success);
   }
 }


### PR DESCRIPTION
0.18.106, fix exitFullScreen freezing obsidian when popout window is closed after moving an embeddable element. attempted fix for polybool