### PR TITLE
Fix: terminate image generation (MarkdownPostProcessor, EmbeddedFilesLoader), addressed image.ts memory leak in Excalidraw package

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-excalidraw-plugin",
   "name": "Excalidraw",
-  "version": "2.25.0-beta.1",
+  "version": "2.25.0-beta.2",
   "minAppVersion": "1.8.7",
   "description": "Sketch Your Mind. Edit and view Excalidraw drawings. Enter the world of 4D Visual PKM.",
   "author": "Zsolt Viczian",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@popperjs/core": "^2.11.8",
         "@radix-ui/number": "^1.1.2",
         "@zsviczian/colormaster": "^1.2.2",
-        "@zsviczian/excalidraw": "0.18.109",
+        "@zsviczian/excalidraw": "0.18.110",
         "chroma-js": "^3.1.2",
         "clsx": "^2.0.0",
         "es6-promise-pool": "2.5.0",
@@ -5232,9 +5232,9 @@
       "license": "MIT"
     },
     "node_modules/@zsviczian/excalidraw": {
-      "version": "0.18.109",
-      "resolved": "https://registry.npmjs.org/@zsviczian/excalidraw/-/excalidraw-0.18.109.tgz",
-      "integrity": "sha512-E1lWFfI8QSnVjFZFiuVpoI6swhestPqbWni2uZnqEGy8Ypq8U7YyYet6wvEOm84xLeGExNel6Ff60UiMIyYevw==",
+      "version": "0.18.110",
+      "resolved": "https://registry.npmjs.org/@zsviczian/excalidraw/-/excalidraw-0.18.110.tgz",
+      "integrity": "sha512-R/5aZ/6Sbk3O/TI0O28kA/KzyeXC61NDXFVjIi5857Lmx2Gvf1Xva3APKoqsnBwiR2aNjB92qBE86AiUyvxmhA==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@popperjs/core": "^2.11.8",
     "@radix-ui/number": "^1.1.2",
     "@zsviczian/colormaster": "^1.2.2",
-    "@zsviczian/excalidraw": "0.18.109",
+    "@zsviczian/excalidraw": "0.18.110",
     "chroma-js": "^3.1.2",
     "clsx": "^2.0.0",
     "es6-promise-pool": "2.5.0",

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -412,7 +412,7 @@ export const FRONTMATTER_KEYS = {
     type: "checkbox",
     depricated: false,
   },
-};
+} as const;
 
 export const CaptureUpdateAction = {
   /**

--- a/src/core/managers/MarkdownPostProcessor.ts
+++ b/src/core/managers/MarkdownPostProcessor.ts
@@ -87,7 +87,9 @@ const discardImage = (el: Element | null) => {
   if (!el) {
     return;
   }
-  const images = isInstanceOfHTMLImageElement(el) ? [el] : Array.from(el.querySelectorAll("img"));
+  const images = isInstanceOfHTMLImageElement(el)
+    ? [el]
+    : Array.from(el.querySelectorAll("img"));
   images.forEach((img) => {
     if (img.src.startsWith("blob:")) {
       URL.revokeObjectURL(img.src);
@@ -551,7 +553,12 @@ const getIMG = async (
       }
       case PreviewImageType.SVG: {
         const img = createEl("div");
-        setImgStyle({ element: img, imgAttributes, onCanvas, isNativeSVG: true });
+        setImgStyle({
+          element: img,
+          imgAttributes,
+          onCanvas,
+          isNativeSVG: true,
+        });
         resultElement = await _getSVGNative({
           filenameParts,
           theme,
@@ -745,12 +752,12 @@ const createImgElement = async (
           imgstyle: [...Array.from(imgOrDiv.classList)],
         },
         onCanvas,
-        parent
+        parent,
       );
       if (!newImg) {
         return;
       }
-      
+
       if (!parent.isConnected) {
         discardImage(newImg);
         return;
@@ -841,18 +848,15 @@ const processReadingMode = async (
           if (!imgDiv) {
             return;
           }
-          
+
           // Ensure we don't attempt to append onto a detached DOM tree
           if (!maybeDrawing.isConnected) {
             discardImage(imgDiv);
             return;
           }
 
-          maybeDrawing.parentElement.replaceChild(
-            imgDiv,
-            maybeDrawing,
-          );
-        })
+          maybeDrawing.parentElement.replaceChild(imgDiv, maybeDrawing);
+        }),
       );
     }
   }
@@ -1172,7 +1176,7 @@ const tmpObsidianWYSIWYG = async (
     }
     internalEmbedDiv.empty();
     const onCanvas = internalEmbedDiv.hasClass("canvas-node-content");
-    
+
     await getGlobalTaskQueue(plugin).addTask(async () => {
       if (!internalEmbedDiv.isConnected) {
         return;
@@ -1246,7 +1250,7 @@ const tmpObsidianWYSIWYG = async (
   internalEmbedDiv.setAttribute("ready", "");
 
   internalEmbedDiv.empty();
-  
+
   await getGlobalTaskQueue(plugin).addTask(async () => {
     if (!internalEmbedDiv.isConnected) {
       return;
@@ -1477,13 +1481,17 @@ const legacyExcalidrawPopoverObserverFn: MutationCallback = (m) => {
       return;
     }
 
-    const img = await getIMG({
-      file,
-      fname: file.path,
-      fwidth: "300",
-      fheight: null,
-      imgstyle: ["excalidraw-svg"],
-    }, false, node);
+    const img = await getIMG(
+      {
+        file,
+        fname: file.path,
+        fwidth: "300",
+        fheight: null,
+        imgstyle: ["excalidraw-svg"],
+      },
+      false,
+      node,
+    );
 
     if (!img) {
       return;

--- a/src/core/managers/MarkdownPostProcessor.ts
+++ b/src/core/managers/MarkdownPostProcessor.ts
@@ -29,6 +29,7 @@ import {
   getParentOfClass,
   isObsidianThemeDark,
   getFileCSSClasses,
+  getSafeFrontmatter,
 } from "../../utils/obsidianUtils";
 import { linkClickModifierType } from "../../utils/modifierkeyHelper";
 import { ImageKey, getImageCache } from "../../shared/ImageCache";
@@ -76,6 +77,24 @@ const getDefaultHeight = (plugin: ExcalidrawPlugin): string => {
     return "";
   }
   return plugin.settings.height;
+};
+
+/**
+ * Utility to aggressively halt background image decoding and free Blob memory
+ * when an element is discarded without being attached to the DOM.
+ */
+const discardImage = (el: Element | null) => {
+  if (!el) {
+    return;
+  }
+  const images = isInstanceOfHTMLImageElement(el) ? [el] : Array.from(el.querySelectorAll("img"));
+  images.forEach((img) => {
+    if (img.src.startsWith("blob:")) {
+      URL.revokeObjectURL(img.src);
+    }
+    // Instantly aborts the browser's background V8 image decoder task
+    img.src = "";
+  });
 };
 
 export const initializeMarkdownPostProcessor = (p: ExcalidrawPlugin) => {
@@ -430,6 +449,7 @@ const _getSVGNative = async ({
 const getIMG = async (
   imgAttributes: imgElementAttributes,
   onCanvas: boolean = false,
+  embedEl?: Node,
 ): Promise<HTMLImageElement | HTMLDivElement> => {
   let file = imgAttributes.file;
   if (!imgAttributes.file) {
@@ -474,66 +494,87 @@ const getIMG = async (
     theme ? theme === "dark" : undefined,
   );
 
+  let terminationTimer: number;
+  if (embedEl) {
+    terminationTimer = window.setInterval(() => {
+      if (!embedEl.isConnected) {
+        loader.terminate = true;
+        window.clearInterval(terminationTimer);
+      }
+    }, 500);
+  }
+
   const cacheReady = getImageCache().isReady();
 
-  await plugin.awaitInit();
-  switch (plugin.settings.previewImageType) {
-    case PreviewImageType.PNG: {
-      const img = createEl("img");
-      setImgStyle({
-        element: img,
-        imgAttributes,
-        onCanvas,
-        isNativeSVG: false,
-      });
-      return await _getPNG({
-        imgAttributes,
-        filenameParts,
-        theme,
-        cacheReady,
-        img,
-        file,
-        exportSettings,
-        loader,
-      });
+  let resultElement: HTMLImageElement | HTMLDivElement = null;
+  try {
+    await plugin.awaitInit();
+    switch (plugin.settings.previewImageType) {
+      case PreviewImageType.PNG: {
+        const img = createEl("img");
+        setImgStyle({
+          element: img,
+          imgAttributes,
+          onCanvas,
+          isNativeSVG: false,
+        });
+        resultElement = await _getPNG({
+          imgAttributes,
+          filenameParts,
+          theme,
+          cacheReady,
+          img,
+          file,
+          exportSettings,
+          loader,
+        });
+        break;
+      }
+      case PreviewImageType.SVGIMG: {
+        const img = createEl("img");
+        setImgStyle({
+          element: img,
+          imgAttributes,
+          onCanvas,
+          isNativeSVG: false,
+        });
+        resultElement = await _getSVGIMG({
+          filenameParts,
+          theme,
+          cacheReady,
+          img,
+          file,
+          exportSettings,
+          loader,
+        });
+        break;
+      }
+      case PreviewImageType.SVG: {
+        const img = createEl("div");
+        setImgStyle({ element: img, imgAttributes, onCanvas, isNativeSVG: true });
+        resultElement = await _getSVGNative({
+          filenameParts,
+          theme,
+          cacheReady,
+          containerElement: img,
+          file,
+          exportSettings,
+          loader,
+          width: imgAttributes.fwidth
+            ? !imgAttributes.fwidth.endsWith("%")
+              ? parseInt(imgAttributes.fwidth)
+              : 6000
+            : undefined,
+        });
+        break;
+      }
     }
-    case PreviewImageType.SVGIMG: {
-      const img = createEl("img");
-      setImgStyle({
-        element: img,
-        imgAttributes,
-        onCanvas,
-        isNativeSVG: false,
-      });
-      return await _getSVGIMG({
-        filenameParts,
-        theme,
-        cacheReady,
-        img,
-        file,
-        exportSettings,
-        loader,
-      });
-    }
-    case PreviewImageType.SVG: {
-      const img = createEl("div");
-      setImgStyle({ element: img, imgAttributes, onCanvas, isNativeSVG: true });
-      return await _getSVGNative({
-        filenameParts,
-        theme,
-        cacheReady,
-        containerElement: img,
-        file,
-        exportSettings,
-        loader,
-        width: imgAttributes.fwidth
-          ? !imgAttributes.fwidth.endsWith("%")
-            ? parseInt(imgAttributes.fwidth)
-            : 6000
-          : undefined,
-      });
+  } finally {
+    if (terminationTimer) {
+      window.clearInterval(terminationTimer);
     }
   }
+  return resultElement;
 };
 
 const addSVGToImgSrc = (
@@ -565,8 +606,9 @@ const addSVGToImgSrc = (
 const createImgElement = async (
   attr: imgElementAttributes,
   onCanvas: boolean = false,
+  embedEl?: Element,
 ): Promise<HTMLElement> => {
-  const imgOrDiv = await getIMG(attr, onCanvas);
+  const imgOrDiv = await getIMG(attr, onCanvas, embedEl);
   if (!imgOrDiv) {
     return null;
   }
@@ -703,12 +745,14 @@ const createImgElement = async (
           imgstyle: [...Array.from(imgOrDiv.classList)],
         },
         onCanvas,
+        parent
       );
       if (!newImg) {
         return;
       }
       
       if (!parent.isConnected) {
+        discardImage(newImg);
         return;
       }
 
@@ -743,8 +787,12 @@ const createImgElement = async (
 const createImageDiv = async (
   attr: imgElementAttributes,
   onCanvas: boolean = false,
+  embedEl?: Element,
 ): Promise<HTMLDivElement> => {
-  const img = await createImgElement(attr, onCanvas);
+  const img = await createImgElement(attr, onCanvas, embedEl);
+  if (!img) {
+    return null;
+  }
   return createDiv(attr.imgstyle.join(" "), (el) => el.append(img));
 };
 
@@ -790,9 +838,13 @@ const processReadingMode = async (
           }
 
           const imgDiv = await processInternalEmbed(maybeDrawing, file);
+          if (!imgDiv) {
+            return;
+          }
           
           // Ensure we don't attempt to append onto a detached DOM tree
           if (!maybeDrawing.isConnected) {
+            discardImage(imgDiv);
             return;
           }
 
@@ -822,7 +874,7 @@ const processInternalEmbed = async (
 
   const src = internalEmbedEl.getAttribute("src");
   if (!src) {
-    return;
+    return null;
   }
 
   //https://github.com/zsviczian/obsidian-excalidraw-plugin/issues/1059
@@ -847,7 +899,7 @@ const processInternalEmbed = async (
       ? fnameParts.linkpartReference
       : "");
   attr.file = file;
-  return await createImageDiv(attr);
+  return await createImageDiv(attr, false, internalEmbedEl);
 };
 
 function getDimensionsFromAliasString(data: string) {
@@ -1004,7 +1056,8 @@ const tmpObsidianWYSIWYG = async (
   if (!plugin.isExcalidrawFile(file)) {
     return;
   }
-  if (ctx.frontmatter?.["excalidraw-embed-md"]) {
+  const safeFrontmatter = getSafeFrontmatter(ctx.frontmatter);
+  if (safeFrontmatter["excalidraw-open-md"]) {
     return;
   }
   if (ctx.remainingNestLevel < 4) {
@@ -1054,7 +1107,8 @@ const tmpObsidianWYSIWYG = async (
 
   if (!plugin.settings.renderImageInHoverPreviewForMDNotes) {
     //const isHoverPopover = internalEmbedDiv.parentElement?.hasClass("hover-popover");
-    const shouldOpenMD = Boolean(ctx.frontmatter?.["excalidraw-open-md"]);
+    const safeFrontmatter = getSafeFrontmatter(ctx.frontmatter);
+    const shouldOpenMD = Boolean(safeFrontmatter["excalidraw-open-md"]);
     if (isHoverPopover && shouldOpenMD) {
       return;
     }
@@ -1124,10 +1178,14 @@ const tmpObsidianWYSIWYG = async (
         return;
       }
 
-      const imgDiv = await createImageDiv(attr, onCanvas);
+      const imgDiv = await createImageDiv(attr, onCanvas, internalEmbedDiv);
+      if (!imgDiv) {
+        return;
+      }
 
       // Check if the user navigated away while the image was generating
       if (!internalEmbedDiv.isConnected) {
+        discardImage(imgDiv);
         return;
       }
 
@@ -1195,9 +1253,13 @@ const tmpObsidianWYSIWYG = async (
     }
 
     const imgDiv = await processInternalEmbed(internalEmbedDiv, file);
+    if (!imgDiv) {
+      return;
+    }
 
     // Abort insertion if the container is no longer connected
     if (!internalEmbedDiv.isConnected) {
+      discardImage(imgDiv);
       return;
     }
 
@@ -1223,9 +1285,14 @@ const tmpObsidianWYSIWYG = async (
         }
 
         const imgDiv = await processInternalEmbed(internalEmbedDiv, file);
+        if (!imgDiv) {
+          return;
+        }
 
         if (internalEmbedDiv.isConnected) {
           internalEmbedDiv.appendChild(imgDiv);
+        } else {
+          discardImage(imgDiv);
         }
       });
     }, 500);
@@ -1279,9 +1346,10 @@ export const markdownPostProcessor = async (
   const isHoverPopover = Boolean(
     containerEl && getParentOfClass(containerEl, "hover-popover"),
   );
+  const safeFrontmatter = getSafeFrontmatter(ctx.frontmatter);
   const isPreview =
     isHoverPopover &&
-    Boolean(ctx?.frontmatter?.["excalidraw-open-md"]) &&
+    Boolean(safeFrontmatter["excalidraw-open-md"]) &&
     !plugin.settings.renderImageInHoverPreviewForMDNotes;
   const embeddedItems = el.querySelectorAll(".internal-embed");
 
@@ -1323,9 +1391,7 @@ export const markdownPostProcessor = async (
   //then I want to hide all embedded items as these will be
   //transcluded text element or some other transcluded content inside the Excalidraw file
   //in reading mode these elements should be hidden
-  const excalidrawFile = Boolean(
-    ctx.frontmatter && "excalidraw-plugin" in ctx.frontmatter,
-  );
+  const excalidrawFile = Boolean(safeFrontmatter["excalidraw-plugin"]);
   if (!(isPreview || isMarkdownReadingMode || isPrinting) && excalidrawFile) {
     setElementDisplay(el, "none");
     return;
@@ -1417,9 +1483,14 @@ const legacyExcalidrawPopoverObserverFn: MutationCallback = (m) => {
       fwidth: "300",
       fheight: null,
       imgstyle: ["excalidraw-svg"],
-    });
+    }, false, node);
+
+    if (!img) {
+      return;
+    }
 
     if (!node.isConnected) {
+      discardImage(img);
       return;
     }
 

--- a/src/core/managers/MarkdownPostProcessor.ts
+++ b/src/core/managers/MarkdownPostProcessor.ts
@@ -44,6 +44,7 @@ import {
 import { ExportSettings } from "src/types/exportUtilTypes";
 import { setElementDisplay } from "src/utils/htmlUtils";
 import { setStyle } from "src/utils/styleUtils";
+import { getGlobalTaskQueue } from "src/shared/GlobalTaskQueue";
 
 interface imgElementAttributes {
   file?: TFile;
@@ -685,8 +686,12 @@ const createImgElement = async (
   eventElement.addEventListener("dblclick", clickEvent);
   eventElement.addEventListener(RERENDER_EVENT, (e) => {
     e.stopPropagation();
-    void (async () => {
+    void getGlobalTaskQueue(plugin).addTask(async () => {
       const parent = imgOrDiv.parentElement;
+      if (!parent || !parent.isConnected) {
+        console.log("exit 7a: aborted RERENDER_EVENT from queue because parent is disconnected");
+        return;
+      }
       const imgMaxWidth = imgOrDiv.style.maxWidth;
       const imgMaxHeigth = imgOrDiv.style.maxHeight;
       const fileSource = imgOrDiv.getAttribute("fileSource");
@@ -703,6 +708,12 @@ const createImgElement = async (
       if (!newImg) {
         return;
       }
+      
+      if (!parent.isConnected) {
+        console.log("exit 7b: aborted RERENDER_EVENT DOM update because parent is disconnected");
+        return;
+      }
+
       parent.empty();
       if (!onCanvas) {
         setStyle(newImg, {
@@ -712,7 +723,7 @@ const createImgElement = async (
       }
       newImg.setAttribute("fileSource", fileSource);
       parent.append(newImg);
-    })();
+    });
   });
   const cssClasses = getFileCSSClasses(attr.file);
   cssClasses.forEach((cssClass) => {
@@ -749,10 +760,12 @@ const processReadingMode = async (
   //Iterating all the containers in the file to check which one is an excalidraw drawing
   //This is a for loop instead of embeddedItems.forEach() because processInternalEmbed at the end
   //is awaited, otherwise excalidraw images would not display in the Kanban plugin
+  const promises: Promise<void>[] = [];
+
   for (const maybeDrawing of embeddedItems) {
     // If the node is detached from the DOM, the user has closed the note or navigated away.
     if (!maybeDrawing.isConnected) {
-      console.log("exit 1: aborted processInternalEmbed because the element is no longer connected to the DOM");
+      console.log("exit 1a: aborted queuing processInternalEmbed because the element is no longer connected to the DOM");
       break;
     }
 
@@ -773,19 +786,32 @@ const processReadingMode = async (
         continue;
       }
 
-      const imgDiv = await processInternalEmbed(maybeDrawing, file);
-      // Ensure we don't attempt to append onto a detached DOM tree
-      if (!maybeDrawing.isConnected) {
-        console.log("exit 2: aborted processInternalEmbed because the element is no longer connected to the DOM");
-        break;
-      }
+      promises.push(
+        getGlobalTaskQueue(plugin).addTask(async () => {
+          if (!maybeDrawing.isConnected) {
+            console.log("exit 1b: aborted processInternalEmbed from queue because the element is no longer connected to the DOM");
+            return;
+          }
 
-      maybeDrawing.parentElement.replaceChild(
-        imgDiv,
-        maybeDrawing,
+          const imgDiv = await processInternalEmbed(maybeDrawing, file);
+          
+          // Ensure we don't attempt to append onto a detached DOM tree
+          if (!maybeDrawing.isConnected) {
+            console.log("exit 2: aborted processInternalEmbed because the element is no longer connected to the DOM");
+            return;
+          }
+
+          maybeDrawing.parentElement.replaceChild(
+            imgDiv,
+            maybeDrawing,
+          );
+        })
       );
     }
   }
+
+  // Await the completion of all generated jobs allowing concurrent processing via the Global Task Queue
+  await Promise.all(promises);
 };
 
 const processInternalEmbed = async (
@@ -1097,53 +1123,61 @@ const tmpObsidianWYSIWYG = async (
     }
     internalEmbedDiv.empty();
     const onCanvas = internalEmbedDiv.hasClass("canvas-node-content");
-    const imgDiv = await createImageDiv(attr, onCanvas);
-
-    // Check if the user navigated away while the image was generating
-    if (!internalEmbedDiv.isConnected) {
-      console.log("exit 3: aborted processInternalEmbed because the element is no longer connected to the DOM");
-      return; 
-    }
-
-    if (markdownEmbed) {
-      //display image on canvas without markdown frame
-      internalEmbedDiv.removeClass("markdown-embed");
-      internalEmbedDiv.removeClass("inline-embed");
-      internalEmbedDiv.addClass("media-embed");
-      internalEmbedDiv.addClass("image-embed");
-      if (
-        !onCanvas &&
-        (isInstanceOfHTMLElement(imgDiv.firstChild) ||
-          isInstanceOfSVGElement(imgDiv.firstChild))
-      ) {
-        setStyle(imgDiv.firstChild, {
-          maxHeight: "100%",
-          maxWidth: null,
-        });
+    
+    await getGlobalTaskQueue(plugin).addTask(async () => {
+      if (!internalEmbedDiv.isConnected) {
+        console.log("exit 3a: aborted createImageDiv from queue because the element is no longer connected to the DOM");
+        return;
       }
-      // Resolve the cyclic size dependency by applying a CSS width and/or height
-      if (
-        !onCanvas &&
-        isHoverPopover &&
-        isInstanceOfHTMLImageElement(imgDiv.firstChild)
-      ) {
-        internalEmbedDiv.style.setProperty(
-          "--popover-width",
-          `${attr.fwidth}px`,
-        );
-        internalEmbedDiv.style.setProperty(
-          "--popover-height",
-          `${attr.fheight}px`,
-        );
-        setStyle(internalEmbedDiv, {
-          width: "var(--popover-width)",
-          height: "var(--popover-height)",
-        });
+
+      const imgDiv = await createImageDiv(attr, onCanvas);
+
+      // Check if the user navigated away while the image was generating
+      if (!internalEmbedDiv.isConnected) {
+        console.log("exit 3b: aborted processInternalEmbed because the element is no longer connected to the DOM");
+        return; 
       }
-      internalEmbedDiv.appendChild(imgDiv.firstChild);
-      return;
-    }
-    internalEmbedDiv.appendChild(imgDiv);
+
+      if (markdownEmbed) {
+        //display image on canvas without markdown frame
+        internalEmbedDiv.removeClass("markdown-embed");
+        internalEmbedDiv.removeClass("inline-embed");
+        internalEmbedDiv.addClass("media-embed");
+        internalEmbedDiv.addClass("image-embed");
+        if (
+          !onCanvas &&
+          (isInstanceOfHTMLElement(imgDiv.firstChild) ||
+            isInstanceOfSVGElement(imgDiv.firstChild))
+        ) {
+          setStyle(imgDiv.firstChild, {
+            maxHeight: "100%",
+            maxWidth: null,
+          });
+        }
+        // Resolve the cyclic size dependency by applying a CSS width and/or height
+        if (
+          !onCanvas &&
+          isHoverPopover &&
+          isInstanceOfHTMLImageElement(imgDiv.firstChild)
+        ) {
+          internalEmbedDiv.style.setProperty(
+            "--popover-width",
+            `${attr.fwidth}px`,
+          );
+          internalEmbedDiv.style.setProperty(
+            "--popover-height",
+            `${attr.fheight}px`,
+          );
+          setStyle(internalEmbedDiv, {
+            width: "var(--popover-width)",
+            height: "var(--popover-height)",
+          });
+        }
+        internalEmbedDiv.appendChild(imgDiv.firstChild);
+        return;
+      }
+      internalEmbedDiv.appendChild(imgDiv);
+    });
     return;
   }
 
@@ -1161,15 +1195,23 @@ const tmpObsidianWYSIWYG = async (
   internalEmbedDiv.setAttribute("ready", "");
 
   internalEmbedDiv.empty();
-  const imgDiv = await processInternalEmbed(internalEmbedDiv, file);
+  
+  await getGlobalTaskQueue(plugin).addTask(async () => {
+    if (!internalEmbedDiv.isConnected) {
+      console.log("exit 4a: aborted processInternalEmbed from queue because the element is no longer connected to the DOM");
+      return;
+    }
 
-  // Abort insertion if the container is no longer connected
-  if (!internalEmbedDiv.isConnected) {
-    console.log("exit 4: aborted processInternalEmbed because the element is no longer connected to the DOM");
-    return;
-  }
+    const imgDiv = await processInternalEmbed(internalEmbedDiv, file);
 
-  internalEmbedDiv.appendChild(imgDiv);
+    // Abort insertion if the container is no longer connected
+    if (!internalEmbedDiv.isConnected) {
+      console.log("exit 4b: aborted processInternalEmbed because the element is no longer connected to the DOM");
+      return;
+    }
+
+    internalEmbedDiv.appendChild(imgDiv);
+  });
 
   //timer to avoid the image flickering when the user is typing
   let timer: number = null;
@@ -1183,14 +1225,20 @@ const tmpObsidianWYSIWYG = async (
     timer = window.setTimeout(() => {
       timer = null;
       internalEmbedDiv.empty();
-      void (async () => {
+      void getGlobalTaskQueue(plugin).addTask(async () => {
+        if (!internalEmbedDiv.isConnected) {
+          console.log("exit 5a: aborted processInternalEmbed from mutation observer queue because element is disconnected");
+          return;
+        }
+
         const imgDiv = await processInternalEmbed(internalEmbedDiv, file);
+
         if (internalEmbedDiv.isConnected) {
           internalEmbedDiv.appendChild(imgDiv);
         } else {
-          console.log("exit 5: aborted processInternalEmbed because the element is no longer connected to the DOM");
+          console.log("exit 5b: aborted processInternalEmbed from mutation observer because the element is no longer connected to the DOM");
         }
-      })();
+      });
     }, 500);
   };
   const observer = DEBUGGING
@@ -1369,7 +1417,12 @@ const legacyExcalidrawPopoverObserverFn: MutationCallback = (m) => {
 
   //this div will be on top of original DIV. By stopping the propagation of the click
   //I prevent the default Obsidian feature of opening the link in the native app
-  void (async () => {
+  void getGlobalTaskQueue(plugin).addTask(async () => {
+    if (!node.isConnected) {
+      console.log("exit 6a: aborted legacy popover generation from queue because node is disconnected");
+      return;
+    }
+
     const img = await getIMG({
       file,
       fname: file.path,
@@ -1377,6 +1430,12 @@ const legacyExcalidrawPopoverObserverFn: MutationCallback = (m) => {
       fheight: null,
       imgstyle: ["excalidraw-svg"],
     });
+
+    if (!node.isConnected) {
+      console.log("exit 6b: aborted legacy popover append because node is disconnected");
+      return;
+    }
+
     const div = createDiv("", (el) => {
       el.appendChild(img);
       el.setAttribute("src", file.path);
@@ -1392,7 +1451,7 @@ const legacyExcalidrawPopoverObserverFn: MutationCallback = (m) => {
       });
     });
     node.appendChild(div);
-  })();
+  });
 };
 
 export const legacyExcalidrawPopoverObserver = DEBUGGING

--- a/src/core/managers/MarkdownPostProcessor.ts
+++ b/src/core/managers/MarkdownPostProcessor.ts
@@ -750,6 +750,12 @@ const processReadingMode = async (
   //This is a for loop instead of embeddedItems.forEach() because processInternalEmbed at the end
   //is awaited, otherwise excalidraw images would not display in the Kanban plugin
   for (const maybeDrawing of embeddedItems) {
+    // If the node is detached from the DOM, the user has closed the note or navigated away.
+    if (!maybeDrawing.isConnected) {
+      console.log("exit 1: aborted processInternalEmbed because the element is no longer connected to the DOM");
+      break;
+    }
+
     //check to see if the file in the src attribute exists
     const fname = maybeDrawing.getAttribute("src")?.split("#")[0];
     if (!fname) {
@@ -767,8 +773,15 @@ const processReadingMode = async (
         continue;
       }
 
+      const imgDiv = await processInternalEmbed(maybeDrawing, file);
+      // Ensure we don't attempt to append onto a detached DOM tree
+      if (!maybeDrawing.isConnected) {
+        console.log("exit 2: aborted processInternalEmbed because the element is no longer connected to the DOM");
+        break;
+      }
+
       maybeDrawing.parentElement.replaceChild(
-        await processInternalEmbed(maybeDrawing, file),
+        imgDiv,
         maybeDrawing,
       );
     }
@@ -1085,6 +1098,13 @@ const tmpObsidianWYSIWYG = async (
     internalEmbedDiv.empty();
     const onCanvas = internalEmbedDiv.hasClass("canvas-node-content");
     const imgDiv = await createImageDiv(attr, onCanvas);
+
+    // Check if the user navigated away while the image was generating
+    if (!internalEmbedDiv.isConnected) {
+      console.log("exit 3: aborted processInternalEmbed because the element is no longer connected to the DOM");
+      return; 
+    }
+
     if (markdownEmbed) {
       //display image on canvas without markdown frame
       internalEmbedDiv.removeClass("markdown-embed");
@@ -1142,6 +1162,13 @@ const tmpObsidianWYSIWYG = async (
 
   internalEmbedDiv.empty();
   const imgDiv = await processInternalEmbed(internalEmbedDiv, file);
+
+  // Abort insertion if the container is no longer connected
+  if (!internalEmbedDiv.isConnected) {
+    console.log("exit 4: aborted processInternalEmbed because the element is no longer connected to the DOM");
+    return;
+  }
+
   internalEmbedDiv.appendChild(imgDiv);
 
   //timer to avoid the image flickering when the user is typing
@@ -1158,7 +1185,11 @@ const tmpObsidianWYSIWYG = async (
       internalEmbedDiv.empty();
       void (async () => {
         const imgDiv = await processInternalEmbed(internalEmbedDiv, file);
-        internalEmbedDiv.appendChild(imgDiv);
+        if (internalEmbedDiv.isConnected) {
+          internalEmbedDiv.appendChild(imgDiv);
+        } else {
+          console.log("exit 5: aborted processInternalEmbed because the element is no longer connected to the DOM");
+        }
       })();
     }, 500);
   };

--- a/src/core/managers/MarkdownPostProcessor.ts
+++ b/src/core/managers/MarkdownPostProcessor.ts
@@ -689,7 +689,6 @@ const createImgElement = async (
     void getGlobalTaskQueue(plugin).addTask(async () => {
       const parent = imgOrDiv.parentElement;
       if (!parent || !parent.isConnected) {
-        console.log("exit 7a: aborted RERENDER_EVENT from queue because parent is disconnected");
         return;
       }
       const imgMaxWidth = imgOrDiv.style.maxWidth;
@@ -710,7 +709,6 @@ const createImgElement = async (
       }
       
       if (!parent.isConnected) {
-        console.log("exit 7b: aborted RERENDER_EVENT DOM update because parent is disconnected");
         return;
       }
 
@@ -765,7 +763,6 @@ const processReadingMode = async (
   for (const maybeDrawing of embeddedItems) {
     // If the node is detached from the DOM, the user has closed the note or navigated away.
     if (!maybeDrawing.isConnected) {
-      console.log("exit 1a: aborted queuing processInternalEmbed because the element is no longer connected to the DOM");
       break;
     }
 
@@ -789,7 +786,6 @@ const processReadingMode = async (
       promises.push(
         getGlobalTaskQueue(plugin).addTask(async () => {
           if (!maybeDrawing.isConnected) {
-            console.log("exit 1b: aborted processInternalEmbed from queue because the element is no longer connected to the DOM");
             return;
           }
 
@@ -797,7 +793,6 @@ const processReadingMode = async (
           
           // Ensure we don't attempt to append onto a detached DOM tree
           if (!maybeDrawing.isConnected) {
-            console.log("exit 2: aborted processInternalEmbed because the element is no longer connected to the DOM");
             return;
           }
 
@@ -1126,7 +1121,6 @@ const tmpObsidianWYSIWYG = async (
     
     await getGlobalTaskQueue(plugin).addTask(async () => {
       if (!internalEmbedDiv.isConnected) {
-        console.log("exit 3a: aborted createImageDiv from queue because the element is no longer connected to the DOM");
         return;
       }
 
@@ -1134,8 +1128,7 @@ const tmpObsidianWYSIWYG = async (
 
       // Check if the user navigated away while the image was generating
       if (!internalEmbedDiv.isConnected) {
-        console.log("exit 3b: aborted processInternalEmbed because the element is no longer connected to the DOM");
-        return; 
+        return;
       }
 
       if (markdownEmbed) {
@@ -1198,7 +1191,6 @@ const tmpObsidianWYSIWYG = async (
   
   await getGlobalTaskQueue(plugin).addTask(async () => {
     if (!internalEmbedDiv.isConnected) {
-      console.log("exit 4a: aborted processInternalEmbed from queue because the element is no longer connected to the DOM");
       return;
     }
 
@@ -1206,7 +1198,6 @@ const tmpObsidianWYSIWYG = async (
 
     // Abort insertion if the container is no longer connected
     if (!internalEmbedDiv.isConnected) {
-      console.log("exit 4b: aborted processInternalEmbed because the element is no longer connected to the DOM");
       return;
     }
 
@@ -1227,7 +1218,7 @@ const tmpObsidianWYSIWYG = async (
       internalEmbedDiv.empty();
       void getGlobalTaskQueue(plugin).addTask(async () => {
         if (!internalEmbedDiv.isConnected) {
-          console.log("exit 5a: aborted processInternalEmbed from mutation observer queue because element is disconnected");
+          observer.disconnect();
           return;
         }
 
@@ -1235,8 +1226,6 @@ const tmpObsidianWYSIWYG = async (
 
         if (internalEmbedDiv.isConnected) {
           internalEmbedDiv.appendChild(imgDiv);
-        } else {
-          console.log("exit 5b: aborted processInternalEmbed from mutation observer because the element is no longer connected to the DOM");
         }
       });
     }, 500);
@@ -1419,7 +1408,6 @@ const legacyExcalidrawPopoverObserverFn: MutationCallback = (m) => {
   //I prevent the default Obsidian feature of opening the link in the native app
   void getGlobalTaskQueue(plugin).addTask(async () => {
     if (!node.isConnected) {
-      console.log("exit 6a: aborted legacy popover generation from queue because node is disconnected");
       return;
     }
 
@@ -1432,7 +1420,6 @@ const legacyExcalidrawPopoverObserverFn: MutationCallback = (m) => {
     });
 
     if (!node.isConnected) {
-      console.log("exit 6b: aborted legacy popover append because node is disconnected");
       return;
     }
 

--- a/src/shared/Dialogs/Messages.ts
+++ b/src/shared/Dialogs/Messages.ts
@@ -28,6 +28,7 @@ I build this plugin as a labor of love. Curious about the philosophy behind it? 
 
 ## Fixed
 - BUG: Double Click to edit from Obsidian in Live preview doesn't work anymore [#2813](${URLs.GITHUB_COM_ZSVICZIAN_OBSIDIAN_EXCALIDRAW_PLUGIN_ISSUES}/2813)
+- Edge cases leading to memory leak and CPU overload when closing a markdown preview while embedded Excalidraw drawings are loading, or closing an ExcalidrawView, while nested images are still loading.
 `,
   "2.24.2": `
   ## Fixed

--- a/src/shared/EmbeddedFileLoader.ts
+++ b/src/shared/EmbeddedFileLoader.ts
@@ -479,6 +479,9 @@ export class EmbeddedFilesLoader {
     hasSVGwithBitmap: boolean;
     loadedFromCache?: boolean;
   }> {
+    if (this.terminate) {
+      return { dataURL: "" as DataURL, hasSVGwithBitmap: false };
+    }
     //debug({where:"EmbeddedFileLoader.getExcalidrawSVG",uid:this.uid,file:file.name});
     const isMask = isMaskFile(this.plugin, file);
     const forceTheme = hasExportTheme(this.plugin, file)
@@ -540,6 +543,10 @@ export class EmbeddedFilesLoader {
         })
       : undefined;
 
+    if (this.terminate) {
+      return { dataURL: "" as DataURL, hasSVGwithBitmap: false };
+    }
+
     if (maybeSVG && cacheValidation === "stale-first") {
       onStaleCacheHit?.();
     }
@@ -581,6 +588,10 @@ export class EmbeddedFilesLoader {
             ),
             inFile instanceof EmbeddedFile ? inFile.colorMap : null,
           ) as SVGSVGElement);
+
+    if (this.terminate) {
+      return { dataURL: "" as DataURL, hasSVGwithBitmap: false };
+    }
 
     //https://stackoverflow.com/questions/51154171/remove-css-filter-on-child-elements
     const imageList = svg.querySelectorAll(
@@ -726,6 +737,10 @@ export class EmbeddedFilesLoader {
               )
             : await app.vault.readBinary(file);
 
+      if (this.terminate) {
+        return null;
+      }
+
       let dURL: DataURL = null;
       let excalidrawLoadedFromCache = false;
       if (isExcalidrawFile) {
@@ -738,6 +753,10 @@ export class EmbeddedFilesLoader {
           cacheValidation: options?.cacheValidation,
           onStaleCacheHit: options?.onStaleCacheHit,
         });
+
+        if (this.terminate) {
+          return null;
+        }
         dURL = res.dataURL;
         hasSVGwithBitmap = res.hasSVGwithBitmap;
         excalidrawLoadedFromCache = !!res.loadedFromCache;
@@ -754,6 +773,10 @@ export class EmbeddedFilesLoader {
       ] = isPDF
         ? await this.pdfToDataURL(file, linkParts, options)
         : [null, null, null, null, false];
+
+      if (this.terminate) {
+        return null;
+      }
 
       let mimeType: MimeType = isPDF ? "image/png" : "image/svg+xml";
 
@@ -781,6 +804,10 @@ export class EmbeddedFilesLoader {
               ? null
               : await getDataURL(ab, mimeType)));
 
+      if (this.terminate) {
+        return null;
+      }
+
       if (!isHyperLink && !dataURL && !isLocalLink) {
         markdownRendererRecursionWatcthdog.add(file);
         try {
@@ -797,6 +824,11 @@ export class EmbeddedFilesLoader {
       }
 
       const size = isPDF ? pdfSize : await getImageSize(dataURL);
+
+      if (this.terminate) {
+        return null;
+      }
+
       return {
         mimeType,
         fileId: await generateIdFromFile(
@@ -913,6 +945,10 @@ export class EmbeddedFilesLoader {
                     ? () => deferredValidationFileIds.add(id)
                     : undefined,
               });
+            if (this.terminate) {
+              return null;
+            }
+
               if (data) {
                 const fileData: FileData = {
                   mimeType: data.mimeType,
@@ -959,11 +995,11 @@ export class EmbeddedFilesLoader {
       let equationItem;
       const equations = excalidrawData.getEquationEntries();
       while (!(equationItem = equations.next()).done) {
-        if (fileIDWhiteList && !fileIDWhiteList.has(equationItem.value[0])) {
+        if (fileIDWhiteList && !fileIDWhiteList.has(equationItem.value[0] as FileId)) {
           continue;
         }
-        const equation = equationItem.value[1];
-        const id = equationItem.value[0];
+        const equation = equationItem.value[1] as {latex: string; isLoaded: boolean;};
+        const id = equationItem.value[0] as FileId;
         yield createSafeLoadTask(
           async () => {
             if (this.terminate) {
@@ -972,6 +1008,9 @@ export class EmbeddedFilesLoader {
             if (!excalidrawData.getEquation(id).isLoaded) {
               const latex = equation.latex;
               const data = await tex2dataURL(latex, 4, this.plugin);
+              if (this.terminate) {
+                return null;
+              }
               if (data) {
                 const fileData = {
                   mimeType: data.mimeType,
@@ -1008,7 +1047,7 @@ export class EmbeddedFilesLoader {
               const result = await mermaidToExcalidraw(data, {
                 themeVariables: { fontSize: "20" },
               });
-              if (!result) {
+              if (!result || this.terminate) {
                 return;
               }
               if (result?.files) {
@@ -1038,6 +1077,9 @@ export class EmbeddedFilesLoader {
                   hasSVGwithBitmap: false,
                   elements: result.elements,
                 });
+                if (this.terminate) {
+                  return;
+                }
                 if (res?.dataURL) {
                   const size = await getImageSize(res.dataURL);
                   const fileData: FileData = {
@@ -1328,6 +1370,9 @@ export class EmbeddedFilesLoader {
       };
 
       const canvas = await renderPage(pageNum);
+      if (this.terminate) {
+        return [null, null, null, null, false];
+      };
       if (canvas) {
         const blob = await new Promise<Blob>((resolve, reject) => {
           canvas.toBlob((pngBlob) => {
@@ -1368,10 +1413,16 @@ export class EmbeddedFilesLoader {
     file: TFile,
     linkParts: LinkParts,
   ): Promise<{ dataURL: DataURL; hasSVGwithBitmap: boolean }> {
+    if (this.terminate) {
+      return { dataURL: "" as DataURL, hasSVGwithBitmap: false };
+    }
     //1.
     //get the markdown text
     let hasSVGwithBitmap = false;
     const transclusion = await getTransclusion(linkParts, plugin.app, file);
+    if (this.terminate) {
+      return { dataURL: "" as DataURL, hasSVGwithBitmap: false };
+    }
     let text = (transclusion.leadingHashes ?? "") + transclusion.contents;
     if (text === "") {
       text =
@@ -1508,16 +1559,25 @@ export class EmbeddedFilesLoader {
       renderComponent,
     );
     renderComponent.unload();
+    if (this.terminate) {
+      return { dataURL: "" as DataURL, hasSVGwithBitmap: false };
+    }
 
     mdDIV
       .querySelectorAll(":scope > *[class^='frontmatter']")
       .forEach((el) => mdDIV.removeChild(el));
 
     await replaceBlobWithBase64(mdDIV); //because image cache returns a blob
+    if (this.terminate) {
+      return { dataURL: "" as DataURL, hasSVGwithBitmap: false };
+    }
     const internalEmbeds = Array.from(
       mdDIV.querySelectorAll("span[class='internal-embed']"),
     );
     for (let i = 0; i < internalEmbeds.length; i++) {
+      if (this.terminate) {
+        return { dataURL: "" as DataURL, hasSVGwithBitmap: false };
+      }
       const el = internalEmbeds[i];
       const src = el.getAttribute("src");
       if (!src) {
@@ -1531,6 +1591,9 @@ export class EmbeddedFilesLoader {
         continue;
       }
       const embeddedFile = await this._getObsidianImage(ef, 1);
+      if (this.terminate) {
+        return { dataURL: "" as DataURL, hasSVGwithBitmap: false };
+      }
       const img = createEl("img");
       if (width) {
         img.setAttribute("width", width);

--- a/src/shared/EmbeddedFileLoader.ts
+++ b/src/shared/EmbeddedFileLoader.ts
@@ -18,7 +18,7 @@ import {
   mainDocument,
 } from "../constants/constants";
 import { createSVG } from "src/utils/excalidrawAutomateUtils";
-import { ExcalidrawData, getTransclusion } from "./ExcalidrawData";
+import { EquationItem, ExcalidrawData, getTransclusion } from "./ExcalidrawData";
 import { t } from "../lang/helpers";
 import { tex2dataURL } from "./LaTeX";
 import ExcalidrawPlugin from "../core/main";
@@ -214,15 +214,15 @@ export class EmbeddedFile {
         this.file.extension.toLowerCase() === "svg")
     ) {
       try {
-        this.colorMap = colorMapJSON
-          ? JSON.parse(colorMapJSON.toLocaleLowerCase())
-          : null;
-      } catch (error) {
-        console.log(
-          `Error parsing colorMap for file ${imgPath}`,
-          this.constructor,
+        this.colorMap = (
+          colorMapJSON ? JSON.parse(colorMapJSON.toLocaleLowerCase()) : null
+        ) as ColorMap | null;
+      } catch (error: unknown) {
+        errorlog({
+          message: `Error parsing colorMap for file ${imgPath}`,
+          context: this.constructor,
           error,
-        );
+        });
         this.colorMap = null;
       }
     }
@@ -429,7 +429,7 @@ export class EmbeddedFilesLoader {
     this.pdfDocs.forEach((pdfDoc) => {
       try {
         pdfDoc.destroy();
-      } catch (e) {
+      } catch (e: unknown) {
         errorlog({ where: "EmbeddedFileLoader.emptyPDFDocsMap", error: e });
       }
     });
@@ -849,7 +849,7 @@ export class EmbeddedFilesLoader {
         pdfPageViewProps,
         renderScale: pdfRenderScale,
       };
-    } catch (error) {
+    } catch (error: unknown) {
       errorlog({
         where: "EmbeddedFileLoader._getObsidianImage",
         uid: this.uid,
@@ -906,7 +906,7 @@ export class EmbeddedFilesLoader {
       promiseTry(async () => {
         try {
           await task();
-        } catch (error) {
+        } catch (error: unknown) {
           errorlog({
             where: "EmbeddedFileLoader.loadSceneFiles",
             uid: this.uid,
@@ -945,9 +945,9 @@ export class EmbeddedFilesLoader {
                     ? () => deferredValidationFileIds.add(id)
                     : undefined,
               });
-            if (this.terminate) {
-              return null;
-            }
+              if (this.terminate) {
+                return null;
+              }
 
               if (data) {
                 const fileData: FileData = {
@@ -995,11 +995,15 @@ export class EmbeddedFilesLoader {
       let equationItem;
       const equations = excalidrawData.getEquationEntries();
       while (!(equationItem = equations.next()).done) {
-        if (fileIDWhiteList && !fileIDWhiteList.has(equationItem.value[0] as FileId)) {
+        const eiValue = equationItem.value as [FileId, EquationItem];
+        if (
+          fileIDWhiteList &&
+          !fileIDWhiteList.has(eiValue[0])
+        ) {
           continue;
         }
-        const equation = equationItem.value[1] as {latex: string; isLoaded: boolean;};
-        const id = equationItem.value[0] as FileId;
+        const equation = eiValue[1];
+        const id = eiValue[0];
         yield createSafeLoadTask(
           async () => {
             if (this.terminate) {
@@ -1059,7 +1063,7 @@ export class EmbeddedFilesLoader {
                     hasSVGwithBitmap: false,
                     shouldScale: true,
                     size: await getImageSize(result.files[key].dataURL),
-                  };
+                  } as FileData;
                   files[batch].push(fileData);
                 }
                 return;
@@ -1372,7 +1376,7 @@ export class EmbeddedFilesLoader {
       const canvas = await renderPage(pageNum);
       if (this.terminate) {
         return [null, null, null, null, false];
-      };
+      }
       if (canvas) {
         const blob = await new Promise<Blob>((resolve, reject) => {
           canvas.toBlob((pngBlob) => {
@@ -1666,9 +1670,7 @@ export class EmbeddedFilesLoader {
     try {
       host.appendChild(svgEl);
       mainDocument.body.appendChild(host);
-      footerHeight = svgEl.querySelector(
-        ".excalidraw-md-footer",
-      ).scrollHeight;
+      footerHeight = svgEl.querySelector(".excalidraw-md-footer").scrollHeight;
       const height =
         svgEl.querySelector(".excalidraw-md-host").scrollHeight + footerHeight;
       svgHeight = height <= linkParts.height ? height : linkParts.height;

--- a/src/shared/EmbeddedFileLoader.ts
+++ b/src/shared/EmbeddedFileLoader.ts
@@ -1550,15 +1550,18 @@ export class EmbeddedFilesLoader {
 
     const renderComponent = new Component();
     renderComponent.load();
-    //await MarkdownRenderer.renderMarkdown(text, mdDIV, file.path, plugin);
-    await MarkdownRenderer.render(
-      this.plugin.app,
-      text,
-      mdDIV,
-      file.path,
-      renderComponent,
-    );
-    renderComponent.unload();
+    try {
+      //await MarkdownRenderer.renderMarkdown(text, mdDIV, file.path, plugin);
+      await MarkdownRenderer.render(
+        this.plugin.app,
+        text,
+        mdDIV,
+        file.path,
+        renderComponent,
+      );
+    } finally {
+      renderComponent.unload();
+    }
     if (this.terminate) {
       return { dataURL: "" as DataURL, hasSVGwithBitmap: false };
     }
@@ -1611,36 +1614,43 @@ export class EmbeddedFilesLoader {
     //blank styles into inline styles using computedStyle
     const iframeHost = mainDocument.body.createDiv();
     hideElement(iframeHost);
-    const iframe = iframeHost.createEl("iframe");
-    const iframeDoc = iframe.contentWindow.document;
-    if (style) {
-      const styleEl = iframeDoc.createElement("style");
-      styleEl.type = "text/css";
-      setStyleText(styleEl, style);
-      iframeDoc.head.appendChild(styleEl);
-    }
-    const stylingDIV = iframeDoc.importNode(mdDIV, true);
-    iframeDoc.body.appendChild(stylingDIV);
-    const footerDIV = createDiv();
-    footerDIV.setAttribute("class", "excalidraw-md-footer");
-    iframeDoc.body.appendChild(footerDIV);
-
-    iframeDoc.body.querySelectorAll("*").forEach((el: HTMLElement) => {
-      const elementStyle = el.style;
-      const computedStyle = window.getComputedStyle(el);
-      let style = "";
-      for (const [prop] of Object.entries(elementStyle)) {
-        if (Object.hasOwn(elementStyle ?? {}, prop)) {
-          const value = computedStyle.getPropertyValue(prop);
-          style += `${prop}: ${value};`;
-        }
+    let xmlINiframe = "";
+    let xmlFooter = "";
+    try {
+      const iframe = iframeHost.createEl("iframe");
+      const iframeDoc = iframe.contentWindow.document;
+      if (style) {
+        const styleEl = iframeDoc.createElement("style");
+        styleEl.type = "text/css";
+        setStyleText(styleEl, style);
+        iframeDoc.head.appendChild(styleEl);
       }
-      el.setAttribute("style", style);
-    });
+      const stylingDIV = iframeDoc.importNode(mdDIV, true);
+      iframeDoc.body.appendChild(stylingDIV);
+      const footerDIV = createDiv();
+      footerDIV.setAttribute("class", "excalidraw-md-footer");
+      iframeDoc.body.appendChild(footerDIV);
 
-    const xmlINiframe = new XMLSerializer().serializeToString(stylingDIV);
-    const xmlFooter = new XMLSerializer().serializeToString(footerDIV);
-    mainDocument.body.removeChild(iframeHost);
+      iframeDoc.body.querySelectorAll("*").forEach((el: HTMLElement) => {
+        const elementStyle = el.style;
+        const computedStyle = window.getComputedStyle(el);
+        let style = "";
+        for (const [prop] of Object.entries(elementStyle)) {
+          if (Object.hasOwn(elementStyle ?? {}, prop)) {
+            const value = computedStyle.getPropertyValue(prop);
+            style += `${prop}: ${value};`;
+          }
+        }
+        el.setAttribute("style", style);
+      });
+
+      xmlINiframe = new XMLSerializer().serializeToString(stylingDIV);
+      xmlFooter = new XMLSerializer().serializeToString(footerDIV);
+    } finally {
+      if (iframeHost.parentElement) {
+        mainDocument.body.removeChild(iframeHost);
+      }
+    }
 
     //5.2
     //get SVG size
@@ -1651,15 +1661,22 @@ export class EmbeddedFilesLoader {
     );
     const svgEl = doc.firstElementChild;
     const host = createDiv();
-    host.appendChild(svgEl);
-    mainDocument.body.appendChild(host);
-    const footerHeight = svgEl.querySelector(
-      ".excalidraw-md-footer",
-    ).scrollHeight;
-    const height =
-      svgEl.querySelector(".excalidraw-md-host").scrollHeight + footerHeight;
-    const svgHeight = height <= linkParts.height ? height : linkParts.height;
-    mainDocument.body.removeChild(host);
+    let svgHeight = 0;
+    let footerHeight = 0;
+    try {
+      host.appendChild(svgEl);
+      mainDocument.body.appendChild(host);
+      footerHeight = svgEl.querySelector(
+        ".excalidraw-md-footer",
+      ).scrollHeight;
+      const height =
+        svgEl.querySelector(".excalidraw-md-host").scrollHeight + footerHeight;
+      svgHeight = height <= linkParts.height ? height : linkParts.height;
+    } finally {
+      if (host.parentElement) {
+        mainDocument.body.removeChild(host);
+      }
+    }
 
     //finalize SVG
     svgStyle = ` width="${linkParts.width}px" height="${svgHeight}px"`;

--- a/src/shared/ExcalidrawData.ts
+++ b/src/shared/ExcalidrawData.ts
@@ -500,6 +500,9 @@ export const getExcalidrawMarkdownHeaderSection = (
       : `${header}\n`;
 };
 
+export type EquationItem = { latex: string; isLoaded: boolean };
+export type MermaidItem = { mermaid: string; isLoaded: boolean };
+
 export class ExcalidrawData {
   public textElements: Map<
     string,
@@ -519,8 +522,8 @@ export class ExcalidrawData {
   public loaded: boolean = false;
   public elementLinks: Map<string, string> = null;
   public files: Map<FileId, EmbeddedFile> = null; //fileId, path
-  private equations: Map<FileId, { latex: string; isLoaded: boolean }> = null; //fileId, path
-  private mermaids: Map<FileId, { mermaid: string; isLoaded: boolean }> = null; //fileId, path
+  private equations: Map<FileId, EquationItem> = null; //fileId, path
+  private mermaids: Map<FileId, MermaidItem> = null; //fileId, path
   private compatibilityMode: boolean = false;
   private textElementCommentedOut: boolean = false;
   selectedElementIds: { [key: string]: boolean } = {}; //https://github.com/zsviczian/obsidian-excalidraw-plugin/issues/609
@@ -531,8 +534,8 @@ export class ExcalidrawData {
   ) {
     this.app = this.plugin.app;
     this.files = new Map<FileId, EmbeddedFile>();
-    this.equations = new Map<FileId, { latex: string; isLoaded: boolean }>();
-    this.mermaids = new Map<FileId, { mermaid: string; isLoaded: boolean }>();
+    this.equations = new Map<FileId, EquationItem>();
+    this.mermaids = new Map<FileId, MermaidItem>();
   }
 
   public destroy() {
@@ -768,8 +771,11 @@ export class ExcalidrawData {
         .forEach((textEl: Mutable<ExcalidrawTextElement>) => {
           textEl.containerId = null;
         }); // log({message:"cleanup",textEl})});
-    } catch (error) {
-      console.log(error);
+    } catch (error: unknown) {
+      errorlog({
+        message: "unexpected error in loadData",
+        error,
+      });
     }
   }
 

--- a/src/shared/GlobalTaskQueue.ts
+++ b/src/shared/GlobalTaskQueue.ts
@@ -1,0 +1,48 @@
+import ExcalidrawPlugin from "src/core/main";
+
+export class GlobalTaskQueue {
+  private queue: { task: () => Promise<void>; resolve: (value: void | PromiseLike<void>) => void; reject: (err: unknown) => void }[] = [];
+  private activeCount = 0;
+
+  constructor (
+    private plugin: ExcalidrawPlugin,
+  ) {
+
+  }
+
+  public async addTask(task: () => Promise<void>): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.queue.push({ task, resolve, reject });
+      void this.processNext();
+    });
+  }
+
+  private async processNext() {
+    const concurrencyLimit = this.plugin?.settings?.renderingConcurrency ?? 4;
+    if (this.activeCount >= concurrencyLimit || this.queue.length === 0) {
+      return;
+    }
+
+    this.activeCount++;
+    const { task, resolve, reject } = this.queue.shift();
+
+    try {
+      await task();
+      resolve();
+    } catch (error) {
+      reject(error);
+    } finally {
+      this.activeCount--;
+      void this.processNext();
+    }
+  }
+}
+
+let globalTaskQueue: GlobalTaskQueue = null;
+
+export const getGlobalTaskQueue = (plugin: ExcalidrawPlugin): GlobalTaskQueue => {
+  if (!globalTaskQueue) {
+    globalTaskQueue = new GlobalTaskQueue(plugin);
+  }
+  return globalTaskQueue;
+};

--- a/src/shared/GlobalTaskQueue.ts
+++ b/src/shared/GlobalTaskQueue.ts
@@ -1,14 +1,14 @@
 import ExcalidrawPlugin from "src/core/main";
 
 export class GlobalTaskQueue {
-  private queue: { task: () => Promise<void>; resolve: (value: void | PromiseLike<void>) => void; reject: (err: unknown) => void }[] = [];
+  private queue: {
+    task: () => Promise<void>;
+    resolve: (value: void | PromiseLike<void>) => void;
+    reject: (err: unknown) => void;
+  }[] = [];
   private activeCount = 0;
 
-  constructor (
-    private plugin: ExcalidrawPlugin,
-  ) {
-
-  }
+  constructor(private plugin: ExcalidrawPlugin) {}
 
   public async addTask(task: () => Promise<void>): Promise<void> {
     return new Promise((resolve, reject) => {
@@ -40,7 +40,9 @@ export class GlobalTaskQueue {
 
 let globalTaskQueue: GlobalTaskQueue = null;
 
-export const getGlobalTaskQueue = (plugin: ExcalidrawPlugin): GlobalTaskQueue => {
+export const getGlobalTaskQueue = (
+  plugin: ExcalidrawPlugin,
+): GlobalTaskQueue => {
   if (!globalTaskQueue) {
     globalTaskQueue = new GlobalTaskQueue(plugin);
   }

--- a/src/utils/obsidianUtils.ts
+++ b/src/utils/obsidianUtils.ts
@@ -18,6 +18,7 @@ import { linkClickModifierType, ModifierKeys } from "./modifierkeyHelper";
 import {
   DEVICE,
   EXCALIDRAW_PLUGIN,
+  FRONTMATTER_KEYS,
   mainDocument,
   VIEW_TYPE_EXCALIDRAW,
 } from "src/constants/constants";
@@ -321,7 +322,7 @@ export const getFileCSSClasses = (file: TFile): string[] => {
     if (!fileCache?.frontmatter) {
       return [];
     }
-    const x = parseFrontMatterEntry(fileCache.frontmatter, "cssclasses");
+    const x = parseFrontMatterEntry(fileCache.frontmatter, "cssclasses") as string | string[];
     if (Array.isArray(x)) {
       return x;
     }
@@ -381,8 +382,8 @@ export function mergeMarkdownFiles(template: string, target: string): string {
     .substring(4, templateFrontmatterEnd)
     .trim();
   const templateContent = template.substring(templateFrontmatterEnd + 3);
-  const templateFrontmatterObj: FrontMatterCache =
-    parse(templateFrontmatterRaw) || {};
+  const templateFrontmatterObj =
+    (parse(templateFrontmatterRaw) || {}) as FrontMatterCache;
 
   const hasTargetFM =
     target.startsWith("---\n") && target.indexOf("---\n", 4) > 0;
@@ -394,7 +395,7 @@ export function mergeMarkdownFiles(template: string, target: string): string {
     const targetContent = target.substring(targetFrontmatterEnd + 3);
 
     const targetFrontmatterObj: FrontMatterCache =
-      parse(targetFrontmatterRaw) || {};
+      (parse(targetFrontmatterRaw) || {}) as FrontMatterCache;
 
     // 1. Merge array keys present in both (target has precedence for ordering)
     const mergeArrayKeys = Object.keys(templateFrontmatterObj).filter(
@@ -661,4 +662,30 @@ export function strictArrayBuffer(
     return strictBuffer;
   }
   return buffer;
+}
+
+// 1. Map your custom 'type' strings to actual TypeScript types
+type FrontmatterTypeMap = {
+  text: string;
+  checkbox: boolean;
+  number: number;
+};
+
+// 2. Automatically infer the shape of your valid frontmatter keys from the object
+type FrontmatterValueType<T extends keyof typeof FRONTMATTER_KEYS> = 
+  FrontmatterTypeMap[typeof FRONTMATTER_KEYS[T]["type"]];
+
+// 3. Construct a fully typed Record where keys are the true names (e.g., "excalidraw-open-md")
+export type ValidFrontmatter = {
+  [K in keyof typeof FRONTMATTER_KEYS as typeof FRONTMATTER_KEYS[K]["name"]]?: FrontmatterValueType<K>;
+};
+
+// 4. Create a reusable type guard function
+export function getSafeFrontmatter(frontmatter: unknown): ValidFrontmatter {
+  if (typeof frontmatter !== "object" || frontmatter === null) {
+    return {};
+  }
+  
+  // Cast safely inside the boundary helper function
+  return frontmatter;
 }

--- a/src/utils/obsidianUtils.ts
+++ b/src/utils/obsidianUtils.ts
@@ -322,7 +322,9 @@ export const getFileCSSClasses = (file: TFile): string[] => {
     if (!fileCache?.frontmatter) {
       return [];
     }
-    const x = parseFrontMatterEntry(fileCache.frontmatter, "cssclasses") as string | string[];
+    const x = parseFrontMatterEntry(fileCache.frontmatter, "cssclasses") as
+      | string
+      | string[];
     if (Array.isArray(x)) {
       return x;
     }
@@ -382,8 +384,8 @@ export function mergeMarkdownFiles(template: string, target: string): string {
     .substring(4, templateFrontmatterEnd)
     .trim();
   const templateContent = template.substring(templateFrontmatterEnd + 3);
-  const templateFrontmatterObj =
-    (parse(templateFrontmatterRaw) || {}) as FrontMatterCache;
+  const templateFrontmatterObj = (parse(templateFrontmatterRaw) ||
+    {}) as FrontMatterCache;
 
   const hasTargetFM =
     target.startsWith("---\n") && target.indexOf("---\n", 4) > 0;
@@ -394,8 +396,9 @@ export function mergeMarkdownFiles(template: string, target: string): string {
       .replace(/\s+$/, ""); // keep as-is
     const targetContent = target.substring(targetFrontmatterEnd + 3);
 
-    const targetFrontmatterObj: FrontMatterCache =
-      (parse(targetFrontmatterRaw) || {}) as FrontMatterCache;
+    const targetFrontmatterObj: FrontMatterCache = (parse(
+      targetFrontmatterRaw,
+    ) || {}) as FrontMatterCache;
 
     // 1. Merge array keys present in both (target has precedence for ordering)
     const mergeArrayKeys = Object.keys(templateFrontmatterObj).filter(
@@ -672,12 +675,12 @@ type FrontmatterTypeMap = {
 };
 
 // 2. Automatically infer the shape of your valid frontmatter keys from the object
-type FrontmatterValueType<T extends keyof typeof FRONTMATTER_KEYS> = 
-  FrontmatterTypeMap[typeof FRONTMATTER_KEYS[T]["type"]];
+type FrontmatterValueType<T extends keyof typeof FRONTMATTER_KEYS> =
+  FrontmatterTypeMap[(typeof FRONTMATTER_KEYS)[T]["type"]];
 
 // 3. Construct a fully typed Record where keys are the true names (e.g., "excalidraw-open-md")
 export type ValidFrontmatter = {
-  [K in keyof typeof FRONTMATTER_KEYS as typeof FRONTMATTER_KEYS[K]["name"]]?: FrontmatterValueType<K>;
+  [K in keyof typeof FRONTMATTER_KEYS as (typeof FRONTMATTER_KEYS)[K]["name"]]?: FrontmatterValueType<K>;
 };
 
 // 4. Create a reusable type guard function
@@ -685,7 +688,7 @@ export function getSafeFrontmatter(frontmatter: unknown): ValidFrontmatter {
   if (typeof frontmatter !== "object" || frontmatter === null) {
     return {};
   }
-  
+
   // Cast safely inside the boundary helper function
   return frontmatter;
 }

--- a/src/view/ExcalidrawView.ts
+++ b/src/view/ExcalidrawView.ts
@@ -3240,11 +3240,16 @@ export default class ExcalidrawView
     this.cancelDeferredSceneFileValidation();
     if (this.activeLoader) {
       this.activeLoader.terminate = true;
+      this.activeLoader.emptyPDFDocsMap();
       this.activeLoader = null;
     }
-    this.nextLoader = null;
+    if (this.nextLoader) {
+      this.nextLoader.terminate = true;
+      this.nextLoader.emptyPDFDocsMap();
+      this.nextLoader = null;
+    }
     this.lastSceneLoadTime = 0;
-    api.resetScene();
+    (api.resetScene as ()=>void)();
     this.previousSceneVersion = 0;
   }
 

--- a/src/view/ExcalidrawView.ts
+++ b/src/view/ExcalidrawView.ts
@@ -3249,7 +3249,7 @@ export default class ExcalidrawView
       this.nextLoader = null;
     }
     this.lastSceneLoadTime = 0;
-    (api.resetScene as ()=>void)();
+    (api.resetScene as () => void)();
     this.previousSceneVersion = 0;
   }
 

--- a/src/view/components/CustomEmbeddable.tsx
+++ b/src/view/components/CustomEmbeddable.tsx
@@ -682,9 +682,7 @@ function RenderObsidianView({
 
     return () => {
       mo.disconnect();
-      const iframe = containerRef.current?.querySelector(
-        "iframe.embed-iframe",
-      );
+      const iframe = containerRef.current?.querySelector("iframe.embed-iframe");
       if (iframe && iframeLoadHandler) {
         iframe.removeEventListener("load", iframeLoadHandler);
       }


### PR DESCRIPTION
Fixed edge cases leading to memory leak and CPU overload when closing a markdown preview while embedded Excalidraw drawings are loading, or closing an ExcalidrawView, while nested images are still loading.

Excalidraw component change: https://github.com/zsviczian/excalidraw/commit/794640e720323ccadfb9f17b92f4eb275f870ee6