### PR TITLE
feat(area): add ,padding=N argument to control area= embed preview margin

### DIFF
--- a/src/shared/Dialogs/Messages.ts
+++ b/src/shared/Dialogs/Messages.ts
@@ -28,6 +28,14 @@ I build this plugin as a labor of love. Curious about the philosophy behind it? 
   - Added \`ea.getCM6()\` to expose CodeMirror 6 classes/functions (EditorView, EditorState, etc.) to the ScriptEngine environment.
   - Added \`ea.getMathEditorExtensions()\` to expose Excalidraw's pre-configured LaTeX editor extensions, natively supporting obsidian-latex-suite integration in custom sidepanel scripts.
 `,
+  "2.25.4": `
+  ## New
+  - Added \`,padding=N\` argument to area= embed links to control how much surrounding context is shown in preview. Useful for large canvases like maps.
+
+  \`\`\`
+  ![[file.excalidraw#^area=elementID,padding=120]]
+  \`\`\`
+`,
   "2.25.2": `
 One more small maintenance release with a few important fixes.
 

--- a/src/shared/ImageCache.ts
+++ b/src/shared/ImageCache.ts
@@ -46,7 +46,7 @@ const getKey = (key: ImageKey): string =>
       : key.previewImageType === PreviewImageType.PNG
         ? 0
         : 2
-  }#${key.scale}${key.isTransparent ? "#t" : ""}`; //key.isSVG ? 1 : 0
+  }#${key.scale}${key.isTransparent ? "#t" : ""}#${key.padding ?? 0}`; //key.isSVG ? 1 : 0
 
 class ImageCache {
   private dbName: string;

--- a/src/types/utilTypes.ts
+++ b/src/types/utilTypes.ts
@@ -13,6 +13,7 @@ export type FILENAMEPARTS = {
   sectionref: string;
   linkpartReference: string;
   linkpartAlias: string;
+  padding?: number;
 };
 
 export enum PreviewImageType {

--- a/src/utils/embeddedAssetUtils.ts
+++ b/src/utils/embeddedAssetUtils.ts
@@ -191,7 +191,7 @@ export function getEmbeddedFilenameParts(fname: string): FILENAMEPARTS {
   let blockref = parts[5];
   let padding: number | undefined;
   if (isArea && blockref) {
-    const m = blockref.match(/,(\d+)$/);
+    const m = blockref.match(/,padding=(\d+)$/);
     if (m) {
       blockref = blockref.slice(0, -m[0].length);
       padding = parseInt(m[1]);

--- a/src/utils/embeddedAssetUtils.ts
+++ b/src/utils/embeddedAssetUtils.ts
@@ -187,20 +187,31 @@ export function getEmbeddedFilenameParts(fname: string): FILENAMEPARTS {
       linkpartAlias: "",
     };
   }
+  const isArea = parts[4] === "area=" || parts[7] === "area=";
+  let blockref = parts[5];
+  let padding: number | undefined;
+  if (isArea && blockref) {
+    const m = blockref.match(/,(\d+)$/);
+    if (m) {
+      blockref = blockref.slice(0, -m[0].length);
+      padding = parseInt(m[1]);
+    }
+  }
   return {
     filepath: parts[1],
     hasBlockref: Boolean(parts[3]),
     hasGroupref: parts[4] === "group=" || parts[7] === "group=",
     hasTaskbone: parts[4] === "taskbone" || parts[7] === "taskbone",
-    hasArearef: parts[4] === "area=" || parts[7] === "area=",
+    hasArearef: isArea,
     hasFrameref: parts[4] === "frame=" || parts[7] === "frame=",
     hasClippedFrameref:
       parts[4] === "clippedframe=" || parts[7] === "clippedframe=",
-    blockref: parts[5],
+    blockref,
     hasSectionref: Boolean(parts[6]),
     sectionref: parts[8],
     linkpartReference: parts[2],
     linkpartAlias: parts[9],
+    padding,
   };
 }
 

--- a/src/utils/excalidrawAutomateUtils.ts
+++ b/src/utils/excalidrawAutomateUtils.ts
@@ -677,6 +677,9 @@ export async function createSVG(
     exportSettings?.withTheme ?? plugin.settings.exportWithTheme;
 
   const filenameParts = getEmbeddedFilenameParts(templatePath);
+  if (filenameParts.hasArearef && filenameParts.padding != null) {
+    padding = filenameParts.padding;
+  }
   const svg = await getSVG(
     {
       //createAndOpenDrawing

--- a/src/utils/excalidrawAutomateUtils.ts
+++ b/src/utils/excalidrawAutomateUtils.ts
@@ -391,7 +391,16 @@ export async function getTemplate(
         (el: ExcalidrawElement) => el.id === filenameParts.blockref,
       );
       if (el) {
-        groupElements = plugin.ea.getElementsInArea(scene.elements, el);
+        const m = filenameParts.padding ?? plugin.settings.exportPaddingSVG;
+        const expanded = cloneElement(el);
+        expanded.x -= m;
+        expanded.y -= m;
+        expanded.width += 2 * m;
+        expanded.height += 2 * m;
+        groupElements = plugin.ea.getElementsInArea(
+          scene.elements,
+          expanded,
+        );
       }
     }
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1001,7 +1001,7 @@ export function getEmbeddedFilenameParts(fname: string): FILENAMEPARTS {
   let blockref = parts[5];
   let padding: number | undefined;
   if (isArea && blockref) {
-    const m = blockref.match(/,(\d+)$/);
+    const m = blockref.match(/,padding=(\d+)$/);
     if (m) {
       blockref = blockref.slice(0, -m[0].length);
       padding = parseInt(m[1]);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -997,20 +997,31 @@ export function getEmbeddedFilenameParts(fname: string): FILENAMEPARTS {
       linkpartAlias: "",
     };
   }
+  const isArea = parts[4] === "area=" || parts[7] === "area=";
+  let blockref = parts[5];
+  let padding: number | undefined;
+  if (isArea && blockref) {
+    const m = blockref.match(/,(\d+)$/);
+    if (m) {
+      blockref = blockref.slice(0, -m[0].length);
+      padding = parseInt(m[1]);
+    }
+  }
   return {
     filepath: parts[1],
     hasBlockref: Boolean(parts[3]),
     hasGroupref: parts[4] === "group=" || parts[7] === "group=",
     hasTaskbone: parts[4] === "taskbone" || parts[7] === "taskbone",
-    hasArearef: parts[4] === "area=" || parts[7] === "area=",
+    hasArearef: isArea,
     hasFrameref: parts[4] === "frame=" || parts[7] === "frame=",
     hasClippedFrameref:
       parts[4] === "clippedframe=" || parts[7] === "clippedframe=",
-    blockref: parts[5],
+    blockref,
     hasSectionref: Boolean(parts[6]),
     sectionref: parts[8],
     linkpartReference: parts[2],
     linkpartAlias: parts[9],
+    padding,
   };
 }
 


### PR DESCRIPTION
Closes #2849

## Summary

Adds a named `,padding=N` argument to `area=` embed links:

```
![[file.excalidraw#^area=elementID,padding=120]]
```

- `N` — search radius in pixels around the target element
- Elements within `N` pixels are captured and shown in the preview
- Without the argument: behavior unchanged (uses `exportPaddingSVG`)


## Testing

- `![[file#^area=id,padding=50]]` → preview with 50px radius
- Change `padding=50` to `padding=200` → cache invalidates, preview updates
- `![[file#^area=id]]` → no argument, original behavior preserved

\* Tested on Linux. Platform-independent change.

