### PR TITLE
fix: reuse existing vault files when importing non-image media

### DIFF
--- a/src/view/managers/DropManager.ts
+++ b/src/view/managers/DropManager.ts
@@ -423,7 +423,9 @@ export class DropManager {
           } else {
             const extension = getURLImageExtension(link.url);
             if (localFileDragAction === "image-import") {
-              if (IMAGE_TYPES.contains(extension)) {
+              if (extension === "excalidraw") {
+                return true; //excalidraw to continue processing
+              } else {
                 void (async () => {
                   const droppedFilename = event.dataTransfer.files[i].name;
                   const fileToImport =
@@ -432,7 +434,8 @@ export class DropManager {
                     droppedFilename,
                     this.file.path,
                   );
-                  if (maybeFile && maybeFile instanceof TFile) {
+                  let file = maybeFile instanceof TFile ? maybeFile : null;
+                  if (file) {
                     const action = await ScriptEngine.suggester(
                       this.app,
                       [
@@ -442,44 +445,28 @@ export class DropManager {
                       ],
                       ["Use", "Overwrite", "Import"],
                       `A file with the same name/path already exists in the Vault\n${
-                        maybeFile.path
+                        file.path
                       }`,
                     );
-                    if (action !== "Import") {
-                      if (action === "Overwrite") {
-                        await this.app.vault.modifyBinary(
-                          maybeFile,
-                          fileToImport,
-                        );
-                      }
-                      const ea = getEA(this.view);
-                      await insertImageToView(ea, pos, maybeFile);
-                      ea.destroy();
-                      return false;
+                    if (action === "Overwrite") {
+                      await this.app.vault.modifyBinary(file, fileToImport);
+                    } else if (action === "Import") {
+                      file = null;
                     }
                   }
-                  const file = await importFileToVault(
+                  file ??= await importFileToVault(
                     this.app,
                     droppedFilename,
                     fileToImport,
                     this.view.file,
                     this.view,
                   );
-                  const ea = getEA(this.view);
-                  await insertImageToView(ea, pos, file);
-                  ea.destroy();
-                })();
-              } else if (extension === "excalidraw") {
-                return true; //excalidraw to continue processing
-              } else {
-                void (async () => {
-                  const file = await importFileToVault(
-                    this.app,
-                    event.dataTransfer.files[i].name,
-                    await event.dataTransfer.files[i].arrayBuffer(),
-                    this.view.file,
-                    this.view,
-                  );
+                  if (IMAGE_TYPES.contains(extension)) {
+                    const ea = getEA(this.view);
+                    await insertImageToView(ea, pos, file);
+                    ea.destroy();
+                    return;
+                  }
                   const modal = new UniversalInsertFileModal(
                     this.plugin,
                     this.view,


### PR DESCRIPTION
Extend the external-file import conflict prompt to videos and other non-image media. Currently only images get the prompt.

The prompt in question:

<img width="895" height="226" alt="image" src="https://github.com/user-attachments/assets/2044d9e1-da92-45d1-87eb-9bfc02c41d1c" />

When a matching vault file is resolved by name/path, users can now reuse it, overwrite it, or import a renamed copy. 
Image behavior remains unchanged.