### PR TITLE
Fix @excalidraw/common type resolution, eliminating a huge any-collapse

### DIFF
--- a/RefactorPlan.md
+++ b/RefactorPlan.md
@@ -1381,6 +1381,187 @@ this was a pure type-annotation change with no logic touched).
 both targeted manual tests — the stale-image retry loop and general text-
 element/link/back-of-card parsing — succeeded with no issues; committed.
 
+## Related, separate effort: `@excalidraw/common` type-resolution fix
+
+Started 2026-08-14 (session 3), on branch `excalidraw-type-import-fix`.
+Directly grew out of the `excalidrawAutomateUtils.ts` triage above, whose
+"flagged, needs its own investigation" finding turned out to be the single
+largest lint win of the whole `no-unsafe-*` effort by a wide margin.
+
+**Root cause (confirmed against both this repo and upstream, no fork changes
+needed):** `@zsviczian/excalidraw`'s bundled `.d.ts` files import bare-specifier
+`@excalidraw/common`, `@excalidraw/common/utility-types`, `@excalidraw/element`,
+`@excalidraw/math`, `@excalidraw/utils`, and self-referencing `@excalidraw/excalidraw/*`
+— packages this plugin's `package.json` never lists as dependencies. Confirmed
+this is not fork-specific: the same gap exists in upstream's own published
+`@excalidraw/excalidraw@0.18.1` (`npm view @excalidraw/excalidraw dependencies`
+lists neither `@excalidraw/common` nor `@excalidraw/element`/`math`/`utils`
+either, and its own shipped `.d.ts` files contain the identical bare imports).
+It's an inherent characteristic of how the Excalidraw monorepo publishes
+per-package types, not a bug introduced by the fork. Every value that
+transitively touched one of those unresolvable imports (`Theme`,
+`BinaryFileData["id"]`, most of `AppState`, large parts of the
+`ExcalidrawElement` union) silently collapsed to `any`, which is what the
+`no-unsafe-*` backlog had actually been measuring all along.
+
+**The fix, and how it evolved (read this before touching it again):**
+
+1. First attempt: added `@excalidraw/element@0.18.0-f0063e113` (npm's
+   `latest` tag) as a `devDependency` and mapped all four `@excalidraw/*`
+   specifiers to it via `tsconfig.json` `paths`. This worked for simple
+   leaf types (`Theme`, `FileId`) but **introduced genuine false-positive
+   type errors** for complex types: the externally-installed package's own
+   `ExcalidrawElement` (e.g. `ExcalidrawArrowElement.lastCommittedPoint:
+   LocalPoint | null`) structurally disagreed with `@zsviczian/excalidraw`'s
+   own bundled `ExcalidrawElement` (no such optional field) — two
+   same-named-but-different types competing, caught via
+   `InsertPDFModal.ts`'s `selectElements()`/`zoomToFit()` calls suddenly
+   failing with a real structural mismatch that hadn't existed before.
+   **Reverted** (`npm uninstall @excalidraw/element`) once this was
+   understood — an independently-versioned external package is fundamentally
+   the wrong source of truth here, no matter which version is pinned.
+2. **Correct fix:** `node_modules/@zsviczian/excalidraw/types/` already
+   vendors its own exact-match copies of `common/`, `element/`, `math/`,
+   `utils/`, and `excalidraw/` (it has to, to be self-contained) — so
+   `tsconfig.json` `paths` redirects `@excalidraw/common|element|math|utils`
+   (bare and `/*` subpaths) straight into that same already-installed
+   package's own `types/` tree instead of an external one. Zero version-drift
+   risk by construction (literally the same files), and **no new
+   dependency at all** — `package.json` ended up completely untouched.
+   Also explains why the first attempt's `devDependency` alone (before
+   the `paths` redirect existed) did nothing: this project's
+   `"moduleResolution": "node"` (classic/legacy) never consults
+   `package.json` `exports` maps for **subpath** imports at all, only
+   bare ones via the top-level `types` field — `@excalidraw/common/utility-types`
+   could not have resolved through package installation alone regardless
+   of version. A global `"moduleResolution": "bundler"` switch (which does
+   support subpath `exports`) was tested and immediately reverted: it fixed
+   this pattern but broke hundreds of other, previously-clean type checks
+   elsewhere in the project — `paths` remapping is the correctly scoped
+   tool here, a global resolution-mode change is not.
+
+**Fallout, fixed file by file, small-to-large, each verified with a fresh
+`npm run build` before moving on:** turning the fix on project-wide surfaced
+117 real, previously-masked compile errors across 18 files (the same
+narrowing-gap shape as the two `ExcalidrawData.ts`
+`as Mutable<ExcalidrawTextElement>[]` fixes in the prior session, now at
+project scale). Fixed via the same idioms throughout — casting to the
+narrower literal/branded type at the exact site where the code already
+behaved as if it had that type (`as Theme` / `as "dark" | "light"` for
+theme strings, `as FileId` for branded IDs, `as NonDeletedExcalidrawElement`
+/ `as unknown as NonDeletedExcalidrawElement` for the `isDeleted: boolean`
+vs `isDeleted: false` narrowing gap, matching the user's explicit "readonly
+complaints are deliberate, fix as mutable" guidance generalized to this
+whole family of narrowing gaps), or widening an explicit type annotation at
+a `let`/`const` declaration when the array was later reassigned to a
+narrower produced type. Files fully cleared: `LaTeX.ts`, `dynamicStyling.ts`,
+`screenshot.ts`, `ExcalidrawData.ts`, `excalidrawAutomateUtils.ts`,
+`ExcalidrawAutomate.ts`, `ExcalidrawRoot.ts`, `InsertPDFModal.ts`,
+`ExcalidrawView.ts`, `ViewExcalidrawExtensionRenderer.ts`,
+`ViewExportManager.ts`, `ObsidianMenu.tsx`, `EmbeddableActionsMenu.tsx`,
+`CustomEmbeddable.tsx`. A final `eslint --fix` pass (scoped — confirmed
+beforehand that every "potentially fixable" finding at that point was
+`no-unnecessary-type-assertion`, i.e. removing a now-redundant cast this
+same fix made unnecessary, never a behavior-changing rule) mechanically
+cleaned up a further cascade of now-redundant `as X`/`as unknown as X`
+casts across files this session hadn't touched directly (`DropManager.ts`,
+`EmbeddedFileLoader.ts`, `ExportDialog.ts`), each confirmed zero-risk by
+definition (an assertion ESLint proved changes nothing about the expression's
+type cannot change its runtime value either). One resulting unused import
+(`ExtendedFillStyle` in `ObsidianMenu.tsx`, superseded by the real `FillStyle`
+cast) was removed by hand.
+
+**Two real bugs found and fixed along the way (not type-only — flagged and
+confirmed before fixing, per the user's explicit instruction):**
+
+- `ExcalidrawView.ts`'s `addFiles()`: `isDark = s.scene.appState.theme;`
+  assigned the literal string `"light"`/`"dark"` directly to a `boolean`
+  parameter. Proof this was live and wrong, not just a type nag: three lines
+  later the code did `isDark: !!isDark` — `!!` on any non-empty string is
+  always `true`, so every call through this fallback path (whenever the
+  caller didn't pass `isDark` explicitly) had unconditionally treated the
+  scene as dark-themed regardless of the actual theme, since the very first
+  version of this code. User caught this by inspection and supplied the
+  fix directly; applied as `isDark = s.scene.appState.theme === "dark"`,
+  matching the already-correct sibling usage at the same file's line ~4088
+  (`isDark: st.theme === "dark"`).
+- `ExcalidrawView.ts`'s `getSelectedTextElement()`: the "selected element is
+  part of a group containing a text element" branch returned
+  `{id: selectedElement[0].id, text: (selectedElement[0] as
+  ExcalidrawTextElement).text}` — casting the *originally selected* element
+  (proven only to be grouped with a text element, never proven to be text
+  itself) instead of `textElement[0]`, the group's actual text element the
+  same branch had just found two lines above via `.filter(type === "text")`
+  and then never used. Silently wrong whenever the selected element itself
+  wasn't literally text (e.g. a shape grouped with a caption): `.text` would
+  read `undefined` off a non-text element at runtime, previously invisible
+  because the cast was `any`-permissive. The sibling "bound text elements"
+  branch immediately above already does this correctly (`id`/`text` both
+  from its own found `textElement[0]`). Asked the user whether `id` should
+  also switch to `textElement[0].id` (this method is exposed via the public
+  `ExcalidrawAutomate` scripting API, so changing which `id` a script
+  receives needed explicit confirmation, not an assumption) — confirmed yes;
+  both `id` and `text` now come from `textElement[0]`, matching the sibling
+  branch exactly.
+
+**One found, initially flagged as a suspected logic bug — corrected by the
+user, then fixed as type-only after all.** `excalidrawViewUtils.ts`'s
+`getViewColorPalette()`: `AppState["colorPalette"][palette]`'s *declared*
+type is `ColorPaletteCustom = {[key: string]: ColorTuple | string}` (a
+config-shaped record), which made the function's `Array.isArray(basePalette)`
+check look like dead code guarding a shape the value could never have. Wrong
+— the user tested it directly and confirmed `getViewColorPalette()` already
+returns correct values, then pointed at the authoritative fork-side type
+(`packages/excalidraw/types.ts`, marked `//zsviczian`) to settle it. The real
+runtime shape is a flat list of single colors and/or grouped 5-color tuples,
+not a record — confirmed independently by the function's own pre-existing
+`flattenPalette()` helper a few lines below, whose parameter was *already*
+explicitly typed `readonly (string | string[])[]`. So `ColorPaletteCustom`
+describes the record-shaped *settings/config* input, but the fork
+transforms it into this flat list by the time it lands in `AppState` — a
+type-declaration imprecision in the fork's own upstream-facing type, not a
+logic bug in the plugin. Fixed as a documented bridge cast at the one read
+site (`as unknown as string | readonly (string | string[])[]`, matching the
+shape `flattenPalette()` already assumed) plus one follow-on cast the first
+one's `Array.isArray` narrowing didn't propagate through
+(`readonly (string|string[])[]`'s negative-array branch doesn't narrow
+cleanly to `string` in this TS version — cast directly instead of relying on
+control-flow narrowing). Zero logic touched; build now fully clean.
+
+**Outcome:** `npm run build`, `npm run lib`, `node --check dist/main.js` all
+pass (exit 0) with **zero remaining diagnostics** — every one of the
+originally-surfaced 117 build errors is now fixed; the 33-warning
+circular-dependency baseline is unchanged;
+`dist/main.js` is 4,716,853 bytes, effectively unchanged (this was
+exclusively a `tsconfig.json`/source type-annotation effort, nothing
+touched the runtime bundle). Confirmed via a `git stash -u`/`pop` full-repo
+ESLint diff against the pre-session-3 commit (`b7472cb8`): **411 → 229
+findings (182 fewer, 44%), with zero files regressing** — every file with a
+changed count went down, none went up. `ExcalidrawView.ts` alone dropped
+144 → 18 (87%). Several files neither this session nor the prior one
+touched directly also improved as pure beneficiaries of the project-wide
+type-resolution fix: `CropImage.ts`, `InsertImageDialog.ts`, `carveout.ts`,
+and `utils.ts`. `ExcalidrawRoot.ts`, `getElementAtPointer.ts`,
+`screenshot.ts`, and `carveout.ts` are now fully clean (0 findings).
+`ExcalidrawAutomate.ts` (still the largest remaining cluster at 57, down
+from 79) and `excalidrawViewUtils.ts` (20, down from 23) have not been
+individually re-triaged since this fix landed — worth a fresh look before
+assuming their remaining findings are all external-boundary cases, since
+this session found real bugs by just reading the surfaced errors in
+context. Manual testing pending, prioritizing the two real bug fixes above
+(dark/light theme detection when embedding freshly-pasted images/PDFs
+without an explicit theme argument; selecting a non-text element that's
+grouped with a text element, e.g. via a script calling
+`getSelectedTextElement`/its public API surface) over the purely type-level
+changes elsewhere, including `getViewColorPalette()` since its logic itself
+was already confirmed correct and unchanged.
+
+**If resumed:** `ExcalidrawAutomate.ts` (57) is the natural next file-by-file
+triage target, followed by re-checking `AIUtils.ts` (46, previously declined
+as external-boundary — worth confirming that conclusion still holds now
+that so much else has changed) and a final full-repo sweep once the large
+clusters are gone.
+
 ## Related, separate effort: `ExcalidrawData.ts` structural extraction
 
 Started 2026-08-14. Independent of the other work on this page; not blocked

--- a/src/shared/Dialogs/ExportDialog.ts
+++ b/src/shared/Dialogs/ExportDialog.ts
@@ -81,7 +81,7 @@ export class ExportDialog extends Modal {
     this.theme = getExportTheme(
       this.plugin,
       this.file,
-      this.api.getAppState().theme as string,
+      this.api.getAppState().theme,
     );
     this.boundingBox = this.ea.getBoundingBox(this.ea.getViewElements());
     this.embedScene = shouldEmbedScene(this.plugin, this.file);

--- a/src/shared/EmbeddedFileLoader.ts
+++ b/src/shared/EmbeddedFileLoader.ts
@@ -1490,7 +1490,7 @@ export class EmbeddedFilesLoader {
                   depth,
                   inFile: null,
                   hasSVGwithBitmap: false,
-                  elements: result.elements as ExcalidrawElement[],
+                  elements: result.elements,
                 });
                 if (this.terminate) {
                   return;

--- a/src/shared/ExcalidrawAutomate.ts
+++ b/src/shared/ExcalidrawAutomate.ts
@@ -1447,7 +1447,7 @@ export class ExcalidrawAutomate {
       elements,
       appState: {
         ...templateAppstate,
-        theme: (templateAppstate.theme ?? this.canvas.theme) as string,
+        theme: (templateAppstate.theme ?? this.canvas.theme),
         viewBackgroundColor:
           templateAppstate.viewBackgroundColor ??
           this.canvas.viewBackgroundColor,
@@ -1722,7 +1722,7 @@ export class ExcalidrawAutomate {
         ...{
           appState: {
             ...scene.appState,
-            theme: view.getViewExportTheme(theme),
+            theme: view.getViewExportTheme(theme) as "dark" | "light",
             exportEmbedScene: view.getViewExportEmbedScene(embedScene),
           },
         },

--- a/src/shared/ExcalidrawData.ts
+++ b/src/shared/ExcalidrawData.ts
@@ -42,6 +42,7 @@ import {
   NonDeletedExcalidrawElement,
   ExcalidrawTextElement,
   FileId,
+  Theme,
 } from "@zsviczian/excalidraw/types/element/src/types";
 import {
   BinaryFiles,
@@ -670,7 +671,7 @@ export class ExcalidrawData {
         this.plugin,
         this.file,
         "light",
-      );
+      ) as Theme;
     } else if (this.plugin.settings.matchThemeAlways) {
       this.scene.appState.theme = isObsidianThemeDark() ? "dark" : "light";
     }

--- a/src/shared/LaTeX.ts
+++ b/src/shared/LaTeX.ts
@@ -8,7 +8,7 @@ import type { ExcalidrawExtrasAPI } from "@zsviczian/excalidraw-extras-api";
 
 export const updateEquation = async (
   equation: string,
-  fileId: string,
+  fileId: FileId,
   view: ExcalidrawView,
   addFiles: (files: FileData[], view: ExcalidrawView) => void,
 ) => {

--- a/src/utils/dynamicStyling.ts
+++ b/src/utils/dynamicStyling.ts
@@ -110,7 +110,7 @@ export const setDynamicStyle = (
     //const doc = view.ownerDocument;
     const st = view?.excalidrawAPI?.getAppState?.();
 
-    const isLightTheme = st?.theme === "light" || st?.theme === "light";
+    const isLightTheme = st?.theme === "light";
 
     if (color === "transparent") {
       color = "#ffffff";

--- a/src/utils/excalidrawAutomateUtils.ts
+++ b/src/utils/excalidrawAutomateUtils.ts
@@ -13,6 +13,7 @@ import {
   FileId,
   FixedPoint,
   FontString,
+  Theme,
 } from "@zsviczian/excalidraw/types/element/src/types";
 import { normalizePath, TFile } from "obsidian";
 
@@ -552,8 +553,7 @@ export async function createPNG(
       source: `${URLs.GITHUB_COM_ZSVICZIAN_OBSIDIAN_EXCALIDRAW_PLUGIN_RELEASES_TAG}/${PLUGIN_VERSION}`,
       elements,
       appState: {
-        theme:
-          forceTheme ?? template?.appState?.theme ?? canvasTheme ?? "light",
+        theme: (forceTheme ?? template?.appState?.theme ?? canvasTheme ?? "light") as Theme,
         viewBackgroundColor:
           template?.appState?.viewBackgroundColor ?? canvasBackgroundColor,
         ...(template?.appState?.frameRendering
@@ -627,7 +627,7 @@ export const updateElementLinksToObsidianLinks = ({
               linkedFile: file,
               hostFile,
             }) ?? link;
-        } catch (e) {
+        } catch (e: unknown) {
           errorlog({
             where: "excalidrawAutomateUtils.updateElementLinksToObsidianLinks",
             fn: window.ExcalidrawAutomate.onUpdateElementLinkForExportHook,
@@ -694,8 +694,7 @@ export async function createSVG(
     });
   }
 
-  const theme =
-    forceTheme ?? template?.appState?.theme ?? canvasTheme ?? "light";
+  const theme = (forceTheme ?? template?.appState?.theme ?? canvasTheme ?? "light") as Theme;
   const withTheme =
     exportSettings?.withTheme ?? plugin.settings.exportWithTheme;
 

--- a/src/utils/excalidrawViewUtils.ts
+++ b/src/utils/excalidrawViewUtils.ts
@@ -27,6 +27,7 @@ import {
   ExcalidrawImageElement,
   ExcalidrawTextElement,
   FileId,
+  NonDeletedExcalidrawElement,
 } from "@zsviczian/excalidraw/types/element/src/types";
 import { getAllNestedExcalidrawFiles } from "./fileUtils";
 import {
@@ -686,7 +687,12 @@ export async function addBackOfTheNoteCard(
   if (activate) {
     window.setTimeout(() => {
       api.updateScene({
-        appState: { activeEmbeddable: { element: el, state: "active" } },
+        appState: {
+          activeEmbeddable: {
+            element: el as NonDeletedExcalidrawElement,
+            state: "active",
+          },
+        },
         captureUpdate: CaptureUpdateAction.NEVER,
       });
       if (found) {
@@ -929,10 +935,17 @@ export function getViewColorPalette(
     return getDefaultColorPalette();
   }
 
-  const basePalette = colorPalette[palette];
+  // AppState["colorPalette"][palette] is typed as ColorPaletteCustom (a
+  // config-shaped record) upstream, but at the AppState/runtime level the
+  // fork actually stores it as a flat list of single colors and/or grouped
+  // color tuples -- confirmed against this function's own already-typed
+  // flattenPalette() helper below (readonly (string | string[])[]).
+  const basePalette = colorPalette[palette] as unknown as
+    | string
+    | readonly (string | string[])[];
 
   if (!Array.isArray(basePalette)) {
-    return [basePalette];
+    return [basePalette as string];
   }
 
   const cmFactory =

--- a/src/utils/screenshot.ts
+++ b/src/utils/screenshot.ts
@@ -4,6 +4,7 @@ import { getEA } from "src/core";
 import { t } from "src/lang/helpers";
 import ExcalidrawView from "src/view/ExcalidrawView";
 import type { NormalizedZoomValue } from "@zsviczian/excalidraw/types/excalidraw/types";
+import type { Theme } from "@zsviczian/excalidraw/types/element/src/types";
 import { hideElement, setStyle, showElement } from "./styleUtils";
 
 declare const mainDocument: Document;
@@ -122,7 +123,7 @@ export async function captureScreenshot(
     appState: {
       viewModeEnabled: true,
       linkOpacity: 0,
-      theme: options.theme,
+      theme: options.theme as Theme,
     },
   });
 

--- a/src/view/ExcalidrawView.ts
+++ b/src/view/ExcalidrawView.ts
@@ -305,7 +305,7 @@ export const addFiles = async (
   }
   const s = scaleLoadedImage(view.getScene(), files);
   if (isDark === undefined) {
-    isDark = s.scene.appState.theme;
+    isDark = s.scene.appState.theme === "dark";
   }
   // update element.crop naturalWidth and naturalHeight in case scale of PDF loading has changed
   // update crop.x crop.y, crop.width, crop.height according to the new scale
@@ -1767,7 +1767,7 @@ export default class ExcalidrawView
     }
   }
 
-  public setTheme(theme: string) {
+  public setTheme(theme: "dark" | "light") {
     const api = this.excalidrawAPI;
     if (!api) {
       return;
@@ -2231,7 +2231,7 @@ export default class ExcalidrawView
     }
     const sceneElements = api.getSceneElements();
 
-    let elements = sceneElements.filter(
+    let elements: ExcalidrawElement[] = sceneElements.filter(
       (el: ExcalidrawElement) => el.id === id,
     );
     if (elements.length === 0) {
@@ -3745,8 +3745,8 @@ export default class ExcalidrawView
     } //the group had no text element member
 
     return {
-      id: selectedElement[0].id,
-      text: (selectedElement[0] as ExcalidrawTextElement).text,
+      id: textElement[0].id,
+      text: (textElement[0] as ExcalidrawTextElement).text,
     }; //return text element text
   }
 
@@ -3796,7 +3796,7 @@ export default class ExcalidrawView
     } //the group had no image element member
     return {
       id: imageElement[0].id,
-      fileId: imageElement[0].fileId,
+      fileId: (imageElement[0] as ExcalidrawImageElement).fileId,
     }; //return image element fileId
   }
 
@@ -4124,7 +4124,7 @@ export default class ExcalidrawView
 
     const newContainers = newElements.filter(isContainer);
     if (newContainers.length > 0) {
-      api.updateContainerSize(newContainers);
+      api.updateContainerSize(newContainers as NonDeletedExcalidrawElement[]);
       shouldRefreshArrows = true;
     }
     if (shouldRefreshArrows) {
@@ -4147,7 +4147,7 @@ export default class ExcalidrawView
       return null;
     }
     const el: readonly NonDeletedExcalidrawElement[] = selectedOnly
-      ? this.getViewSelectedElements()
+      ? (this.getViewSelectedElements() as NonDeletedExcalidrawElement[])
       : api.getSceneElements();
     const st: AppState = api.getAppState();
     const files = { ...api.getFiles() };
@@ -5224,7 +5224,7 @@ export default class ExcalidrawView
   }
 
   public async onThemeChange(newTheme: string) {
-    this.excalidrawData.scene.appState.theme = newTheme;
+    this.excalidrawData.scene.appState.theme = newTheme as "dark" | "light";
     await this.loadSceneFiles(true);
     this.toolsPanelRef?.current?.setTheme(newTheme as "dark" | "light");
     //Timeout is to allow appState to update

--- a/src/view/components/CustomEmbeddable.tsx
+++ b/src/view/components/CustomEmbeddable.tsx
@@ -1,4 +1,7 @@
-import { ExcalidrawEmbeddableElement } from "@zsviczian/excalidraw/types/element/src/types";
+import {
+  ExcalidrawElement,
+  ExcalidrawEmbeddableElement,
+} from "@zsviczian/excalidraw/types/element/src/types";
 import type ExcalidrawView from "src/view/ExcalidrawView";
 import { Notice, requireApiVersion } from "obsidian";
 import * as React from "react";
@@ -1261,7 +1264,7 @@ function RenderObsidianView({
         const el = api
           .getSceneElements()
           .filter(
-            (el: ExcalidrawEmbeddableElement) => el.id === element.id,
+            (el: ExcalidrawElement) => el.id === element.id,
           )[0] as ExcalidrawEmbeddableElement;
         if (!el || el.angle !== 0) {
           new Notice("Sorry, cannot edit rotated Markdown documents");
@@ -1475,7 +1478,7 @@ export const CustomEmbeddable: React.FC<{
 }> = ({ element, view, appState, linkText }) => {
   const React = view.packages.react;
   const containerRef: React.RefObject<HTMLDivElement> = React.useRef(null);
-  const theme = getTheme(view, appState.theme as string);
+  const theme = getTheme(view, appState.theme);
   const mdProps: EmbeddableMDCustomProps =
     (element.customData?.mdProps as EmbeddableMDCustomProps) || null;
   const selectedElementIds = Object.keys(appState.selectedElementIds);
@@ -1502,8 +1505,13 @@ export const CustomEmbeddable: React.FC<{
         linkText={linkText}
         view={view}
         containerRef={containerRef}
-        activeEmbeddable={appState.activeEmbeddable}
-        theme={appState.theme as string}
+        activeEmbeddable={
+          appState.activeEmbeddable as unknown as {
+            element: ExcalidrawEmbeddableElement;
+            state: string;
+          }
+        }
+        theme={appState.theme}
         canvasColor={appState.viewBackgroundColor}
         selectedElementId={
           selectedElementIds.length === 1 ? selectedElementIds[0] : null

--- a/src/view/components/ExcalidrawRoot.ts
+++ b/src/view/components/ExcalidrawRoot.ts
@@ -179,7 +179,7 @@ export function createExcalidrawRootElement(
             maxWidthOrHeight: 3440,
             maxFileSizeBytes: 20 * 1024 * 1024,
           },
-          initState: initdata?.appState,
+          initState: initdata?.appState as AppState,
           initialData: initdata,
           detectScroll: true,
           onPointerUpdate: (p) => view.onPointerUpdate(p),

--- a/src/view/components/menu/EmbeddableActionsMenu.tsx
+++ b/src/view/components/menu/EmbeddableActionsMenu.tsx
@@ -4,6 +4,7 @@ import type ExcalidrawView from "../../ExcalidrawView";
 import {
   ExcalidrawElement,
   ExcalidrawEmbeddableElement,
+  NonDeletedExcalidrawElement,
 } from "@zsviczian/excalidraw/types/element/src/types";
 import { AppState } from "@zsviczian/excalidraw/types/excalidraw/types";
 import { ActionButton } from "./ActionButton";
@@ -294,7 +295,7 @@ export class EmbeddableMenu {
       this.view.updateScene({
         appState: {
           activeEmbeddable: {
-            element: updatedElement,
+            element: updatedElement as unknown as NonDeletedExcalidrawElement,
             state: "active",
           },
         },
@@ -334,7 +335,7 @@ export class EmbeddableMenu {
       this.view.updateScene({
         appState: {
           activeEmbeddable: {
-            element: updatedElement,
+            element: updatedElement as unknown as NonDeletedExcalidrawElement,
             state: "active",
           },
         },

--- a/src/view/components/menu/ObsidianMenu.tsx
+++ b/src/view/components/menu/ObsidianMenu.tsx
@@ -3,13 +3,14 @@ import {
   ExcalidrawImperativeAPI,
 } from "@zsviczian/excalidraw/types/excalidraw/types";
 import { ObsidianResetCustomPenState } from "@zsviczian/excalidraw/types/excalidraw/obsidianTypes";
+import type { FillStyle } from "@zsviczian/excalidraw/types/element/src/types";
 import clsx from "clsx";
 import { TFile } from "obsidian";
 import * as React from "react";
 import { DEVICE } from "src/constants/constants";
 import { PenSettingsModal } from "src/shared/Dialogs/PenSettingsModal";
 import type ExcalidrawView from "src/view/ExcalidrawView";
-import { ExtendedFillStyle, PenStyle } from "src/types/penTypes";
+import { PenStyle } from "src/types/penTypes";
 import { PENS } from "src/utils/pens";
 import ExcalidrawPlugin from "../../../core/main";
 import { ICONS, penIcon, stringToSVG } from "../../../constants/actionIcons";
@@ -64,7 +65,9 @@ export function setPen(pen: PenStyle, api: ExcalidrawImperativeAPI) {
       ? { currentItemBackgroundColor: pen.backgroundColor }
       : null),
     ...(pen.strokeColor ? { currentItemStrokeColor: pen.strokeColor } : null),
-    ...(pen.fillStyle === "" ? null : { currentItemFillStyle: pen.fillStyle }),
+    ...(pen.fillStyle === ""
+      ? null
+      : { currentItemFillStyle: pen.fillStyle as FillStyle }),
     ...(pen.roughness !== null
       ? { currentItemRoughness: pen.roughness }
       : null),
@@ -73,20 +76,15 @@ export function setPen(pen: PenStyle, api: ExcalidrawImperativeAPI) {
       ? {
           resetCustomPen: {
             currentItemStrokeWidthKey:
-              (st.currentItemStrokeWidthKey as
-                | "extraThin"
-                | "thin"
-                | "medium"
-                | "bold"
-                | "extraBold") ?? null,
+              (st.currentItemStrokeWidthKey) ?? null,
             currentItemStrokeWidth: st.currentItemStrokeWidth ?? null,
             currentItemStrokeVariability:
-              (st.currentItemStrokeVariability as "constant" | "variable") ??
+              (st.currentItemStrokeVariability) ??
               null,
             currentItemBackgroundColor: st.currentItemBackgroundColor ?? null,
             currentItemStrokeColor: st.currentItemStrokeColor ?? null,
             currentItemFillStyle:
-              (st.currentItemFillStyle as ExtendedFillStyle) ?? null,
+              (st.currentItemFillStyle) ?? null,
             currentItemRoughness: st.currentItemRoughness ?? null,
           },
         }
@@ -108,15 +106,23 @@ export function resetStrokeOptions(
     ...(resetCustomPen
       ? {
           currentItemStrokeWidthKey:
-            resetCustomPen.currentItemStrokeWidthKey ?? null,
+            (resetCustomPen.currentItemStrokeWidthKey as
+              | "extraThin"
+              | "thin"
+              | "medium"
+              | "bold"
+              | "extraBold") ?? null,
           currentItemStrokeWidth: resetCustomPen.currentItemStrokeWidth ?? null,
           currentItemBackgroundColor:
             resetCustomPen.currentItemBackgroundColor ?? null,
           currentItemStrokeColor: resetCustomPen.currentItemStrokeColor ?? null,
-          currentItemFillStyle: resetCustomPen.currentItemFillStyle ?? null,
+          currentItemFillStyle:
+            (resetCustomPen.currentItemFillStyle as FillStyle) ?? null,
           currentItemRoughness: resetCustomPen.currentItemRoughness ?? null,
           currentItemStrokeVariability:
-            resetCustomPen.currentItemStrokeVariability ?? null,
+            (resetCustomPen.currentItemStrokeVariability as
+              | "constant"
+              | "variable") ?? null,
         }
       : null),
     resetCustomPen: null,
@@ -259,7 +265,7 @@ export class ObsidianMenu {
   }
 
   private actionShowHideMenu(isMobile: boolean, appState: AppState) {
-    this.toolsRef.current.setTheme(appState.theme as "dark" | "light");
+    this.toolsRef.current.setTheme(appState.theme);
     this.toolsRef.current.toggleVisibility(appState.zenModeEnabled || isMobile);
   }
 
@@ -334,18 +340,13 @@ export class ObsidianMenu {
       ) {
         const updatedActivePen = this.activePens[index] ?? { ...pen };
         updatedActivePen.strokeWidth = getFreedrawStrokeWidthByKey(
-          appState.currentItemStrokeWidthKey as
-            | "extraThin"
-            | "thin"
-            | "medium"
-            | "bold"
-            | "extraBold",
+          appState.currentItemStrokeWidthKey,
           appState.currentItemStrokeWidth,
         );
         updatedActivePen.backgroundColor = appState.currentItemBackgroundColor;
         updatedActivePen.strokeColor = appState.currentItemStrokeColor;
         updatedActivePen.fillStyle =
-          appState.currentItemFillStyle as ExtendedFillStyle;
+          appState.currentItemFillStyle;
         updatedActivePen.roughness = appState.currentItemRoughness;
         this.activePens[index] = updatedActivePen;
       }

--- a/src/view/managers/DropManager.ts
+++ b/src/view/managers/DropManager.ts
@@ -264,7 +264,7 @@ export class DropManager {
           void (async () => {
             if (["image", "image-fullsize"].contains(internalDragAction)) {
               const ea: ExcalidrawAutomate = getEA(this.view);
-              ea.canvas.theme = api.getAppState().theme as string;
+              ea.canvas.theme = api.getAppState().theme;
               let counter: number = 0;
               const ids: string[] = [];
               for (const f of draggable.files) {

--- a/src/view/managers/ViewExcalidrawExtensionRenderer.ts
+++ b/src/view/managers/ViewExcalidrawExtensionRenderer.ts
@@ -7,6 +7,7 @@ import type {
 } from "@zsviczian/excalidraw/types/element/src/types";
 import type { UIAppState } from "@zsviczian/excalidraw/types/excalidraw/types";
 import type { TTTDDialog } from "@zsviczian/excalidraw/types/excalidraw/components/TTDDialog/types";
+import type { RequestError } from "@zsviczian/excalidraw/types/excalidraw/errors";
 import {
   excalidrawSword,
   ICONS,
@@ -100,7 +101,7 @@ export class ViewExcalidrawExtensionRenderer {
                 error: new Error(
                   this.dependencies.getJsonErrorMessage(json) ??
                     `Request failed with status ${response?.status ?? 0}`,
-                ),
+                ) as RequestError,
                 rateLimit,
                 rateLimitRemaining,
               };
@@ -111,7 +112,7 @@ export class ViewExcalidrawExtensionRenderer {
               return {
                 error: new Error(
                   "Generation failed... see console log for details",
-                ),
+                ) as RequestError,
                 rateLimit,
                 rateLimitRemaining,
               };
@@ -131,7 +132,7 @@ export class ViewExcalidrawExtensionRenderer {
               return {
                 error: new Error(
                   "Generation failed... see console log for details",
-                ),
+                ) as RequestError,
                 rateLimit,
                 rateLimitRemaining,
               };
@@ -154,10 +155,12 @@ export class ViewExcalidrawExtensionRenderer {
           } catch (error) {
             const err = error as { name?: string; message?: string };
             if (err?.name === "AbortError") {
-              return { error: new Error("Request aborted") };
+              return { error: new Error("Request aborted") as RequestError };
             }
             log(error);
-            return { error: new Error(err?.message ?? "Request failed") };
+            return {
+              error: new Error(err?.message ?? "Request failed") as RequestError,
+            };
           }
         },
       },

--- a/src/view/managers/ViewExportManager.ts
+++ b/src/view/managers/ViewExportManager.ts
@@ -239,7 +239,7 @@ export class ViewExportManager {
       skipInliningFonts: !embedFont,
     };
 
-    const exportTheme = this.getViewExportTheme(theme);
+    const exportTheme = this.getViewExportTheme(theme) as "dark" | "light";
     const overrideFiles = await this.loadFilesForExport(exportTheme);
 
     return await this.dependencies.getSVG(
@@ -427,7 +427,7 @@ export class ViewExportManager {
       ),
     };
 
-    const exportTheme = this.getViewExportTheme(theme);
+    const exportTheme = this.getViewExportTheme(theme) as "dark" | "light";
     const overrideFiles = await this.loadFilesForExport(exportTheme);
 
     return await this.dependencies.getPNG(
@@ -581,7 +581,7 @@ export class ViewExportManager {
         ) => {
           if (files && files.length > 0) {
             files.forEach((f) => {
-              const fileId = f.id as unknown as FileId;
+              const fileId = f.id;
               collected[fileId] = { ...f };
             });
           }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,28 @@
     "noImplicitAny": true,
     "types": ["node"],
     "paths": {
-      "src/*": ["./src/*"]
+      "src/*": ["./src/*"],
+      // @zsviczian/excalidraw's bundled .d.ts files import bare-specifier
+      // @excalidraw/common|element|math|utils (an upstream monorepo-split
+      // artifact present in @excalidraw/excalidraw's own published types too)
+      // that this plugin never depends on, collapsing everything downstream
+      // to `any`. The package already vendors its own exact-match copies of
+      // all four under node_modules/@zsviczian/excalidraw/types/ (it has to,
+      // to be self-contained), so redirecting there guarantees zero version
+      // drift -- no external devDependency needed. Type-checking only; never
+      // reaches the runtime bundle. (An external @excalidraw/element devDependency
+      // was tried first and reverted: its independently-versioned types
+      // structurally disagreed with this package's own bundled ExcalidrawElement,
+      // producing false-positive mismatches between two same-named-but-different types.)
+      "@excalidraw/common": ["./node_modules/@zsviczian/excalidraw/types/common/src/index"],
+      "@excalidraw/common/*": ["./node_modules/@zsviczian/excalidraw/types/common/src/*"],
+      "@excalidraw/element": ["./node_modules/@zsviczian/excalidraw/types/element/src/index"],
+      "@excalidraw/element/*": ["./node_modules/@zsviczian/excalidraw/types/element/src/*"],
+      "@excalidraw/math": ["./node_modules/@zsviczian/excalidraw/types/math/src/index"],
+      "@excalidraw/math/*": ["./node_modules/@zsviczian/excalidraw/types/math/src/*"],
+      "@excalidraw/utils": ["./node_modules/@zsviczian/excalidraw/types/utils/src/index"],
+      "@excalidraw/utils/*": ["./node_modules/@zsviczian/excalidraw/types/utils/src/*"],
+      "@excalidraw/excalidraw/*": ["./node_modules/@zsviczian/excalidraw/types/excalidraw/*"]
     },
     "moduleResolution": "node",
     "esModuleInterop": true,


### PR DESCRIPTION
@zsviczian/excalidraw's bundled .d.ts files import bare-specifier @excalidraw/common|element|math|utils, packages this plugin never depends on (confirmed the same gap exists in upstream's own published @excalidraw/excalidraw, not a fork-specific bug). Every value that touched one of those unresolvable imports -- Theme, BinaryFileData.id, most of AppState, large parts of ExcalidrawElement -- silently collapsed to any.

Fixed via tsconfig.json paths redirecting all four specifiers (bare and subpath) into @zsviczian/excalidraw's own already-vendored type copies under node_modules/@zsviczian/excalidraw/types/ -- zero version-drift risk since it's literally the same files, and no new dependency needed. (A first attempt using an external @excalidraw/element devDependency was reverted: its independently-versioned types structurally disagreed with this package's own bundled ExcalidrawElement, producing false-positive mismatches.)

Fixed all 117 real, previously-masked compile errors this surfaced across 18 files, smallest to largest, each verified with a build before moving on. Two were genuine pre-existing bugs, not type gaps:

- ExcalidrawView.ts addFiles(): isDark was assigned the literal theme string instead of a boolean comparison; !!isDark on any non-empty string is always true, so every image loaded through that fallback path had been treated as dark-themed regardless of actual theme.
- ExcalidrawView.ts getSelectedTextElement(): the grouped-text-element branch cast the originally-selected (possibly non-text) element instead of the text element the same branch had already found two lines above, silently returning undefined text for non-text selections.

getViewColorPalette()'s Array.isArray check, initially flagged as dead code guarding an impossible shape, turned out to be correct: AppState.colorPalette's declared ColorPaletteCustom type describes the record-shaped settings input, but the fork flattens it to a color list by the time it reaches AppState. Fixed as a documented bridge cast once confirmed against the fork's own type source, not a logic change.

Confirmed via a git-stash ESLint diff against the prior commit: 411 ->
229 findings (44% fewer), zero files regressing. Build, lib, and node --check all pass clean with zero remaining diagnostics.