### PR TITLE
Fix stale canvas offsets when the view moves without resizing

### DIFF
--- a/src/core/managers/EventManager.ts
+++ b/src/core/managers/EventManager.ts
@@ -136,6 +136,12 @@ export class EventManager {
       ),
     );
 
+    //theme/snippet toggles can change header/toolbar heights and shift the canvas
+    //without firing layout-change; refresh cached canvas offsets the same way
+    this.registerEvent(
+      this.app.workspace.on("css-change", () => this.onLayoutChangeHandler()),
+    );
+
     //File Save Trigger Handlers
     //Save the drawing if the user clicks outside the Excalidraw Canvas
     const onClickEventSaveActiveDrawing = (e: PointerEvent) =>

--- a/src/view/ExcalidrawView.ts
+++ b/src/view/ExcalidrawView.ts
@@ -479,6 +479,7 @@ export default class ExcalidrawView
   private resizeBatchTimer: number | null = null;
   private resizeBatchWindowStart: number = 0;
   private lastAggregatedDh = 0;
+  private lastOffsetDriftCheck: number = 0;
   private oldKeyboardScroll: { scrollY: number; scrollX: number } | null = null;
 
   //https://stackoverflow.com/questions/27132796/is-there-any-javascript-event-fired-when-the-on-screen-keyboard-on-mobile-safari
@@ -1613,6 +1614,39 @@ export default class ExcalidrawView
     this.previousContentElHeight = this.contentEl.clientHeight;
     ro.observe(this.contentEl);
     this.destroyers.push(() => ro.disconnect());
+
+    //Guard against stale canvas offsets. Excalidraw caches offsetLeft/offsetTop in
+    //appState and only recalculates when its container RESIZES (its internal
+    //ResizeObserver) or scrolls. When another plugin injects UI above the canvas
+    //after view init (e.g. obsidian-editing-toolbar) or the tab header wraps,
+    //.excalidraw-wrapper (height:100%) is pushed down WITHOUT a size change, so
+    //neither Excalidraw's ResizeObserver nor the parentMoveObserver fires, and
+    //pointer/selection events land a few pixels off the cursor until the next
+    //autosave tick refreshes the offsets (up to 60s later).
+    //https://github.com/zsviczian/obsidian-excalidraw-plugin/issues/1544
+    const offsetDriftGuard = () => {
+      const now = Date.now();
+      if (now - this.lastOffsetDriftCheck < 250) {
+        return;
+      }
+      this.lastOffsetDriftCheck = now;
+      const api = this.excalidrawAPI;
+      const container = this.excalidrawContainer;
+      if (!api || !container) {
+        return;
+      }
+      const { left, top } = container.getBoundingClientRect();
+      const { offsetLeft, offsetTop } = api.getAppState();
+      if (Math.abs(left - offsetLeft) > 1 || Math.abs(top - offsetTop) > 1) {
+        this.refreshCanvasOffset();
+      }
+    };
+    //pointerenter catches drift before the click lands (mouse); the capture-phase
+    //pointerdown is the fallback for touch/pen where enter and down coincide
+    this.registerDomEvent(this.containerEl, "pointerenter", offsetDriftGuard);
+    this.registerDomEvent(this.containerEl, "pointerdown", offsetDriftGuard, {
+      capture: true,
+    });
 
     this.app.workspace.onLayoutReady(async () => {
       //Leaf was moved to new window and ExcalidrawView was destructed.

--- a/src/view/ExcalidrawView.ts
+++ b/src/view/ExcalidrawView.ts
@@ -1624,7 +1624,7 @@ export default class ExcalidrawView
     //pointer/selection events land a few pixels off the cursor until the next
     //autosave tick refreshes the offsets (up to 60s later).
     //https://github.com/zsviczian/obsidian-excalidraw-plugin/issues/1544
-    const offsetDriftGuard = () => {
+    const offsetDriftGuard = (e: PointerEvent) => {
       const now = Date.now();
       if (now - this.lastOffsetDriftCheck < 250) {
         return;
@@ -1637,12 +1637,32 @@ export default class ExcalidrawView
       }
       const { left, top } = container.getBoundingClientRect();
       const { offsetLeft, offsetTop } = api.getAppState();
-      if (Math.abs(left - offsetLeft) > 1 || Math.abs(top - offsetTop) > 1) {
-        this.refreshCanvasOffset();
+      if (Math.abs(left - offsetLeft) <= 1 && Math.abs(top - offsetTop) <= 1) {
+        return;
       }
+      //On the pointerdown path the refresh must land BEFORE React processes
+      //this same event, or the first click/stroke still uses the stale
+      //offsets. This capture listener on an ancestor runs ahead of React's
+      //delegated handlers, so flushSync commits the corrected offsets in
+      //time. Legal here: we are in a native event listener, not a lifecycle.
+      if (e.type === "pointerdown") {
+        const { flushSync } = this.packages.reactDOM as unknown as {
+          flushSync?: (fn: () => void) => void;
+        };
+        if (flushSync) {
+          try {
+            flushSync(() => this.refreshCanvasOffset());
+            return;
+          } catch {
+            //fall through to the async refresh below
+          }
+        }
+      }
+      this.refreshCanvasOffset();
     };
     //pointerenter catches drift before the click lands (mouse); the capture-phase
-    //pointerdown is the fallback for touch/pen where enter and down coincide
+    //pointerdown covers touch/pen where enter and down coincide, and flushes
+    //synchronously so even the first tap after a layout shift lands true
     this.registerDomEvent(this.containerEl, "pointerenter", offsetDriftGuard);
     this.registerDomEvent(this.containerEl, "pointerdown", offsetDriftGuard, {
       capture: true,


### PR DESCRIPTION
## The bug

Sometimes the canvas and the cursor quietly disagree: selection handles sit a few pixels away from where you grab them, and new shapes land slightly above or below the pen. It feels random, and a tiny window resize makes everything snap back into place.

This is #1544, and the "feels random" part turned out to have a precise explanation.

## Why it happens

Excalidraw caches the canvas position (`offsetLeft`/`offsetTop`) and recalculates it when its container resizes or scrolls. But several things in Obsidian can *move* the canvas without resizing anything: a toolbar row injected by another plugin (obsidian-editing-toolbar in my case), a wrapping tab header, a theme or snippet toggle. `.excalidraw-wrapper` is `height: 100%`, so the canvas gets pushed down at the same size. No ResizeObserver callback, no scroll event, no attribute mutation for the parentMoveObserver (#572) - the cached offsets just go stale.

The reason it always seemed to fix itself: the autosave timer calls `refreshCanvasOffset()` on every tick, so the offsets silently heal within about 60 seconds on desktop. The bug is the gap between the layout shift and that tick.

## The fix

A small drift guard: on `pointerenter` (throttled to every 250ms, with a capture-phase `pointerdown` fallback for touch and pen), compare the container's actual bounding rect to the cached appState offsets, and if they disagree by more than a pixel, call the existing `refreshCanvasOffset()`. `pointerenter` fires on mouse hover well before the click, so by the time you press, the offsets are already corrected. Cost is one `getBoundingClientRect` per canvas entry.

A second one-line hunk mirrors the existing `layout-change` refresh for `css-change`, since theme and snippet toggles can shift the canvas the same way. Happy to drop that hunk if you prefer the minimal version.

Verified with `npm run dev` and eslint (no new findings), and tested in my own vault: open a drawing, toggle a plugin that injects a toolbar row, click an element - previously the selection landed offset until the next autosave; with the patch, the first hover corrects it. Manually tested in the main window and a popout.

## Why I care

I teach Recording Arts at Southwestern College, and this plugin quietly became the backbone of how I teach: **337 Excalidraw drawings** explain our SSL console, patchbays, and signal flow to students on my course site, midimaze.com. I am absolutely indebted to this plugin. This offset was the one thing standing between me and frictionless drawing, so I wanted to be the one to chase it down. Thank you for building and maintaining this, Zsolt.

Fixes #1544. Related history: #572, #573.
