### PR TITLE
Add strict LaTeX error handling to Excalidraw Automate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "@types/node": "^22.19.19",
         "@types/react": "19.2.18",
         "@types/react-dom": "19.2.4",
-        "@zsviczian/excalidraw-extras-api": "^0.0.13",
+        "@zsviczian/excalidraw-extras-api": "^0.1.1",
         "@zsviczian/rollup-plugin-postprocess": "^1.0.3",
         "cross-env": "^7.0.3",
         "cssnano": "^6.0.2",
@@ -5298,9 +5298,9 @@
       }
     },
     "node_modules/@zsviczian/excalidraw-extras-api": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@zsviczian/excalidraw-extras-api/-/excalidraw-extras-api-0.0.13.tgz",
-      "integrity": "sha512-rZBkwfq2J5wjgxvaRTdDbGd0jSrDhznNjJ6soPS9FiuErhwDN4aGUQAJSVECaAiV/2Nynh2/iFadEj3RznaslQ==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@zsviczian/excalidraw-extras-api/-/excalidraw-extras-api-0.1.1.tgz",
+      "integrity": "sha512-q0EoXFWEF63DJTqIHPTxrR/fkF6NxUKJVb4bYwE1IZYV9sAmB0PTcRp+ib9u4v7zuhkNiYaZO/QAgreZ4uh/Pw==",
       "dev": true,
       "license": "0-BSD",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@types/node": "^22.19.19",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4",
-    "@zsviczian/excalidraw-extras-api": "^0.0.13",
+    "@zsviczian/excalidraw-extras-api": "^0.1.1",
     "@zsviczian/rollup-plugin-postprocess": "^1.0.3",
     "cross-env": "^7.0.3",
     "cssnano": "^6.0.2",

--- a/src/constants/safeUrls.ts
+++ b/src/constants/safeUrls.ts
@@ -62,6 +62,10 @@ export const URL_REGISTRY = {
     "https://github.com/zsviczian/obsidian-excalidraw-plugin/issues",
     UrlPurpose.DOCS,
   ),
+  GITHUB_COM_ZSVICZIAN_OBSIDIAN_EXCALIDRAW_EXTRAS_ISSUES: defineUrl(
+    "https://github.com/zsviczian/obsidian-excalidraw-extras/issues",
+    UrlPurpose.RELEASE_LOG,
+  ),
   API_OPENAI_COM_V1: defineUrl("https://api.openai.com/v1", UrlPurpose.AI_API),
   API_ANTHROPIC_COM_V1: defineUrl(
     "https://api.anthropic.com/v1",

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -14,6 +14,7 @@ export type {
   StrokeStyle,
 } from "@zsviczian/excalidraw/types/element/src/types";
 export type { Point } from "src/types/types";
+export type { MathJaxRenderOptions } from "src/types/mathJaxTypes";
 export const getEA = (view?: ExcalidrawView): ExcalidrawAutomate | null => {
   try {
     return window.ExcalidrawAutomate.getAPI(view);

--- a/src/shared/Dialogs/Messages.ts
+++ b/src/shared/Dialogs/Messages.ts
@@ -19,6 +19,7 @@ I build this plugin as a labor of love. Curious about the philosophy behind it? 
 `,
 "2.27.3": `
 ## Fixed and updated
+- Excalidraw Automate scripts can now opt into strict LaTeX validation with \`{ throwOnError: true }\` in \`addLaTex()\` and \`tex2dataURL()\`, allowing scripts such as ExcaliMath to catch and display MathJax errors. Requires Excalidraw Extras 0.1.0. [#2](${URLs.GITHUB_COM_ZSVICZIAN_OBSIDIAN_EXCALIDRAW_EXTRAS_ISSUES}/2)
 - Slideshow script now supports better slide sorter, setting slide titles and some other UX improvements.
 - Local Markdown images copied between drawings now retain their back-of-note text, render after reopening, and no longer trigger repeated deletion confirmations.
 - You can now toggle whether deleting a local Markdown image keeps or deletes its back-of-note text, and reset the choice in plugin settings.

--- a/src/shared/Dialogs/SuggesterInfo.ts
+++ b/src/shared/Dialogs/SuggesterInfo.ts
@@ -481,14 +481,14 @@ export const EXCALIDRAW_AUTOMATE_INFO: SuggesterInfo[] = [
   },
   {
     field: "addLaTex",
-    code: "async addLaTex(topX: number, topY: number, tex: string): Promise<string>;",
-    desc: "This is an async function, you need to avait the results. Adds a LaTex element to the drawing. The tex string is the LaTex code. The function returns the id of the created element.",
+    code: "async addLaTex(topX: number, topY: number, tex: string, scaleX: number = 1, scaleY: number = 1, options?: {throwOnError?: boolean}): Promise<string>;",
+    desc: "This is an async function; await the result. Adds a LaTeX element to the drawing and returns its ID. Set options.throwOnError to true to catch invalid LaTeX errors in your script.",
     after: "",
   },
   {
     field: "tex2dataURL",
-    code: "async tex2dataURL(tex: string, scale: number = 4): Promise<{mimeType: MimeType;fileId: FileId;dataURL: DataURL;created: number;size: { height: number; width: number };}> ",
-    desc: "returns the base64 dataURL of the LaTeX equation rendered as an SVG. tex is the LaTeX equation string",
+    code: "async tex2dataURL(tex: string, scale: number = 4, options?: {throwOnError?: boolean}): Promise<{mimeType: MimeType;fileId: FileId;dataURL: DataURL;created: number;size: { height: number; width: number };}> ",
+    desc: "Returns the base64 dataURL of the LaTeX equation rendered as an SVG. Set options.throwOnError to true to catch invalid LaTeX errors in your script.",
     after: "",
   },
   {

--- a/src/shared/ExcalidrawAutomate.ts
+++ b/src/shared/ExcalidrawAutomate.ts
@@ -89,6 +89,7 @@ import {
 } from "@zsviczian/excalidraw/types/excalidraw/types";
 import { EmbeddedFile, EmbeddedFilesLoader } from "./EmbeddedFileLoader";
 import { tex2dataURL } from "./LaTeX";
+import type { MathJaxRenderOptions } from "src/types/mathJaxTypes";
 import {
   LatexSuitePlugin,
   MultiOptionConfirmationPrompt,
@@ -2987,6 +2988,7 @@ export class ExcalidrawAutomate {
    * @param {string} tex - The LaTeX equation string.
    * @param {number} [scaleX=1] - The x-scaling factor (post mathjax creation)
    * @param {number} [scaleY=1] - The y-scaling factor (post mathjax creation)
+   * @param {MathJaxRenderOptions} [options] - MathJax rendering options. Set `throwOnError` to propagate invalid LaTeX errors.
    * @returns {Promise<string>} Promise resolving to the ID of the added LaTeX image element.
    */
   async addLaTex(
@@ -2995,12 +2997,13 @@ export class ExcalidrawAutomate {
     tex: string,
     scaleX: number = 1,
     scaleY: number = 1,
+    options?: MathJaxRenderOptions,
   ): Promise<string> {
     if (!tex || !scaleX || !scaleY) {
       return null;
     }
     const id = nanoid();
-    const image = await tex2dataURL(tex, 4, this.plugin);
+    const image = await tex2dataURL(tex, 4, this.plugin, options);
     if (!image) {
       return null;
     }
@@ -3034,11 +3037,13 @@ export class ExcalidrawAutomate {
    * Returns the base64 dataURL of the LaTeX equation rendered as an SVG.
    * @param {string} tex - The LaTeX equation string.
    * @param {number} [scale=4] - The scale factor for the image.
+   * @param {MathJaxRenderOptions} [options] - MathJax rendering options. Set `throwOnError` to propagate invalid LaTeX errors.
    * @returns {Promise<{mimeType: MimeType; fileId: FileId; dataURL: DataURL; created: number; size: { height: number; width: number };}>} Promise resolving to the LaTeX image data.
    */
   async tex2dataURL(
     tex: string,
     scale: number = 4, // Default scale value, adjust as needed
+    options?: MathJaxRenderOptions,
   ): Promise<{
     mimeType: MimeType;
     fileId: FileId;
@@ -3046,7 +3051,7 @@ export class ExcalidrawAutomate {
     created: number;
     size: { height: number; width: number };
   }> {
-    return await tex2dataURL(tex, scale, this.plugin);
+    return await tex2dataURL(tex, scale, this.plugin, options);
   }
 
   /**

--- a/src/shared/LaTeX.ts
+++ b/src/shared/LaTeX.ts
@@ -5,6 +5,14 @@ import { FileData, MimeType } from "src/types/embeddedFileLoaderTypes";
 import { FileId } from "@zsviczian/excalidraw/types/element/src/types";
 import ExcalidrawPlugin from "src/core/main";
 import type { ExcalidrawExtrasAPI } from "@zsviczian/excalidraw-extras-api";
+import type { MathJaxRenderOptions } from "src/types/mathJaxTypes";
+
+type Tex2DataURLWithOptions = (
+  tex: string,
+  scale?: number,
+  preamble?: string | null,
+  options?: MathJaxRenderOptions,
+) => ReturnType<ExcalidrawExtrasAPI["mathjax"]["tex2dataURL"]>;
 
 export const updateEquation = async (
   equation: string,
@@ -33,6 +41,7 @@ export async function tex2dataURL(
   tex: string,
   scale: number = 4,
   plugin: ExcalidrawPlugin,
+  options?: MathJaxRenderOptions,
 ): Promise<{
   mimeType: MimeType;
   fileId: FileId;
@@ -59,13 +68,22 @@ export async function tex2dataURL(
   }
 
   // 3. Hand the request off to the cleanly isolated Extras plugin
-  return (await mathjaxAPI.tex2dataURL(tex, scale, preambleStr)) as {
+  // The runtime component version gate guarantees this additive signature even
+  // while the separately published API typings remain on the previous version.
+  const mathjaxAPIWithOptions: { tex2dataURL: Tex2DataURLWithOptions } =
+    mathjaxAPI;
+  return (await mathjaxAPIWithOptions.tex2dataURL(
+    tex,
+    scale,
+    preambleStr,
+    options,
+  )) as {
     mimeType: MimeType;
     fileId: FileId;
     dataURL: DataURL;
     created: number;
     size: { height: number; width: number };
-  };
+  } | null;
 }
 
 export const clearMathJaxVariables = (plugin: ExcalidrawPlugin) => {

--- a/src/types/mathJaxTypes.ts
+++ b/src/types/mathJaxTypes.ts
@@ -1,0 +1,5 @@
+/** Options for rendering LaTeX through the Excalidraw Extras MathJax service. */
+export interface MathJaxRenderOptions {
+  /** Propagate MathJax conversion errors instead of returning null. */
+  throwOnError?: boolean;
+}

--- a/src/utils/ExcalidrawExtrasGateway.ts
+++ b/src/utils/ExcalidrawExtrasGateway.ts
@@ -14,7 +14,7 @@ const REQUIRED_EXTRAS_VERSIONS: Record<
   { min?: string; exact?: string }
 > = {
   plugin: { min: "0.0.15" },
-  mathjax: { min: "1.0.0" },
+  mathjax: { min: "1.1.0" },
   mermaid: { exact: "2.2.2" },
   pdf: { min: "1.0.0" },
   filesystem: { min: "1.0.0" },


### PR DESCRIPTION
## Summary

- Extend `ea.addLaTex()` and `ea.tex2dataURL()` with optional `{ throwOnError: true }` support.
- Preserve existing behavior for callers that omit the option.
- Require the updated MathJax component/API from Excalidraw Extras.
- Document the new scripting behavior in the 2.27.3 release notes and API suggester.

Paired with zsviczian/obsidian-excalidraw-extras#4.
Resolves zsviczian/obsidian-excalidraw-extras#2.
